### PR TITLE
feat(viz): Add TrajectoryRenderer for flight path visualization

### DIFF
--- a/Assets/Editor/TrajectoryLineGenerator.cs
+++ b/Assets/Editor/TrajectoryLineGenerator.cs
@@ -1,0 +1,302 @@
+// ABOUTME: Editor tool that generates the TrajectoryLine prefab and material.
+// ABOUTME: Creates properly configured LineRenderer with gradient for trajectory visualization.
+
+using UnityEditor;
+using UnityEngine;
+using UnityEngine.Rendering;
+
+namespace OpenRange.Editor
+{
+    /// <summary>
+    /// Editor utility to generate the TrajectoryLine prefab and material.
+    /// </summary>
+    public static class TrajectoryLineGenerator
+    {
+        private const string MaterialsPath = "Assets/Materials/Effects";
+        private const string PrefabsPath = "Assets/Prefabs/Effects";
+
+        [MenuItem("OpenRange/Create Trajectory Line Prefab", priority = 155)]
+        public static void CreateTrajectoryLinePrefab()
+        {
+            if (!EditorUtility.DisplayDialog(
+                "Create Trajectory Line Prefab",
+                "This will create the TrajectoryLine prefab and material. Existing files will be overwritten. Continue?",
+                "Create",
+                "Cancel"))
+            {
+                return;
+            }
+
+            EnsureDirectoriesExist();
+
+            // Create material first
+            var material = CreateTrajectoryLineMaterial();
+
+            // Create prediction material
+            var predictionMaterial = CreatePredictionLineMaterial();
+
+            // Create main trajectory line prefab
+            CreateTrajectoryLinePrefabAsset(material, predictionMaterial);
+
+            AssetDatabase.Refresh();
+            Debug.Log("TrajectoryLineGenerator: Trajectory line prefab and materials created successfully!");
+        }
+
+        [MenuItem("OpenRange/Create Trajectory Line Material Only", priority = 156)]
+        public static void CreateTrajectoryLineMaterialOnly()
+        {
+            EnsureDirectoriesExist();
+            CreateTrajectoryLineMaterial();
+            CreatePredictionLineMaterial();
+            AssetDatabase.Refresh();
+            Debug.Log("TrajectoryLineGenerator: Trajectory line materials created");
+        }
+
+        private static void EnsureDirectoriesExist()
+        {
+            if (!AssetDatabase.IsValidFolder("Assets/Materials"))
+            {
+                AssetDatabase.CreateFolder("Assets", "Materials");
+            }
+            if (!AssetDatabase.IsValidFolder(MaterialsPath))
+            {
+                AssetDatabase.CreateFolder("Assets/Materials", "Effects");
+            }
+            if (!AssetDatabase.IsValidFolder("Assets/Prefabs"))
+            {
+                AssetDatabase.CreateFolder("Assets", "Prefabs");
+            }
+            if (!AssetDatabase.IsValidFolder(PrefabsPath))
+            {
+                AssetDatabase.CreateFolder("Assets/Prefabs", "Effects");
+            }
+        }
+
+        /// <summary>
+        /// Creates the trajectory line material (for actual path).
+        /// </summary>
+        private static Material CreateTrajectoryLineMaterial()
+        {
+            // Use URP unlit shader for clean line rendering
+            Shader lineShader = Shader.Find("Universal Render Pipeline/Particles/Unlit");
+            if (lineShader == null)
+            {
+                lineShader = Shader.Find("Particles/Standard Unlit");
+            }
+            if (lineShader == null)
+            {
+                // Fallback to unlit shader
+                lineShader = Shader.Find("Unlit/Color");
+            }
+
+            var material = new Material(lineShader);
+            material.name = "TrajectoryLine";
+
+            // Set up for additive blending for a glowing effect
+            material.SetColor("_BaseColor", new Color(1f, 1f, 1f, 1f));
+
+            // Set rendering mode to additive
+            if (material.HasProperty("_Surface"))
+            {
+                material.SetFloat("_Surface", 1f); // Transparent
+            }
+            if (material.HasProperty("_Blend"))
+            {
+                material.SetFloat("_Blend", 1f); // Additive
+            }
+
+            // Render queue for transparent objects
+            material.renderQueue = (int)RenderQueue.Transparent;
+
+            // Save material
+            string materialPath = $"{MaterialsPath}/TrajectoryLine.mat";
+            AssetDatabase.CreateAsset(material, materialPath);
+            Debug.Log($"TrajectoryLineGenerator: Created trajectory material at {materialPath}");
+
+            return material;
+        }
+
+        /// <summary>
+        /// Creates the prediction line material (different color/style).
+        /// </summary>
+        private static Material CreatePredictionLineMaterial()
+        {
+            // Use URP unlit shader for clean line rendering
+            Shader lineShader = Shader.Find("Universal Render Pipeline/Particles/Unlit");
+            if (lineShader == null)
+            {
+                lineShader = Shader.Find("Particles/Standard Unlit");
+            }
+            if (lineShader == null)
+            {
+                lineShader = Shader.Find("Unlit/Color");
+            }
+
+            var material = new Material(lineShader);
+            material.name = "PredictionLine";
+
+            // Yellow-orange color for prediction
+            material.SetColor("_BaseColor", new Color(1f, 0.8f, 0.2f, 0.8f));
+
+            // Set rendering mode to transparent
+            if (material.HasProperty("_Surface"))
+            {
+                material.SetFloat("_Surface", 1f); // Transparent
+            }
+            if (material.HasProperty("_Blend"))
+            {
+                material.SetFloat("_Blend", 0f); // Alpha blend
+            }
+
+            // Render queue for transparent objects
+            material.renderQueue = (int)RenderQueue.Transparent - 1;
+
+            // Save material
+            string materialPath = $"{MaterialsPath}/PredictionLine.mat";
+            AssetDatabase.CreateAsset(material, materialPath);
+            Debug.Log($"TrajectoryLineGenerator: Created prediction material at {materialPath}");
+
+            return material;
+        }
+
+        /// <summary>
+        /// Creates the TrajectoryLine prefab with LineRenderer and TrajectoryRenderer.
+        /// </summary>
+        private static void CreateTrajectoryLinePrefabAsset(Material material, Material predictionMaterial)
+        {
+            // Create root object
+            var lineGo = new GameObject("TrajectoryLine");
+
+            // Add main LineRenderer for actual trajectory
+            var lineRenderer = lineGo.AddComponent<LineRenderer>();
+            ConfigureLineRenderer(lineRenderer, material, CreateActualGradient());
+
+            // Create child for prediction line
+            var predictionGo = new GameObject("PredictionLine");
+            predictionGo.transform.SetParent(lineGo.transform);
+            predictionGo.transform.localPosition = Vector3.zero;
+
+            var predictionLineRenderer = predictionGo.AddComponent<LineRenderer>();
+            ConfigureLineRenderer(predictionLineRenderer, predictionMaterial, CreatePredictionGradient());
+
+            // Add TrajectoryRenderer component
+            var trajectoryRenderer = lineGo.AddComponent<Visualization.TrajectoryRenderer>();
+
+            // Wire up references using SerializedObject
+            var so = new SerializedObject(trajectoryRenderer);
+            so.FindProperty("_lineRenderer").objectReferenceValue = lineRenderer;
+            so.FindProperty("_predictionLineRenderer").objectReferenceValue = predictionLineRenderer;
+            so.FindProperty("_displayMode").enumValueIndex = 0; // Actual mode
+            so.FindProperty("_lineWidthStart").floatValue = 0.05f;
+            so.FindProperty("_lineWidthEnd").floatValue = 0.01f;
+            so.FindProperty("_vertexCountHigh").intValue = 100;
+            so.FindProperty("_vertexCountMedium").intValue = 50;
+            so.FindProperty("_vertexCountLow").intValue = 20;
+            so.FindProperty("_yardsToUnits").floatValue = 0.9144f;
+            so.FindProperty("_feetToUnits").floatValue = 0.3048f;
+
+            // Set up gradients
+            SetSerializedGradient(so, "_actualColorGradient", CreateActualGradient());
+            SetSerializedGradient(so, "_predictionColorGradient", CreatePredictionGradient());
+
+            so.ApplyModifiedPropertiesWithoutUndo();
+
+            // Save as prefab
+            string prefabPath = $"{PrefabsPath}/TrajectoryLine.prefab";
+            PrefabUtility.SaveAsPrefabAsset(lineGo, prefabPath);
+            Object.DestroyImmediate(lineGo);
+
+            Debug.Log($"TrajectoryLineGenerator: Created trajectory line prefab at {prefabPath}");
+        }
+
+        /// <summary>
+        /// Configure a LineRenderer with standard settings.
+        /// </summary>
+        private static void ConfigureLineRenderer(LineRenderer lineRenderer, Material material, Gradient colorGradient)
+        {
+            // Width
+            lineRenderer.startWidth = 0.05f;
+            lineRenderer.endWidth = 0.01f;
+
+            // Material
+            lineRenderer.material = material;
+
+            // Color gradient
+            lineRenderer.colorGradient = colorGradient;
+
+            // Use world space
+            lineRenderer.useWorldSpace = true;
+
+            // Corner and cap vertices for smoothness
+            lineRenderer.numCornerVertices = 5;
+            lineRenderer.numCapVertices = 5;
+
+            // No shadows for trajectory line
+            lineRenderer.shadowCastingMode = ShadowCastingMode.Off;
+            lineRenderer.receiveShadows = false;
+
+            // Sorting order
+            lineRenderer.sortingOrder = 1;
+
+            // Initially disabled
+            lineRenderer.enabled = false;
+            lineRenderer.positionCount = 0;
+        }
+
+        /// <summary>
+        /// Create the default gradient for actual trajectory (white to cyan).
+        /// </summary>
+        private static Gradient CreateActualGradient()
+        {
+            var gradient = new Gradient();
+            gradient.SetKeys(
+                new GradientColorKey[]
+                {
+                    new GradientColorKey(Color.white, 0f),
+                    new GradientColorKey(new Color(0.5f, 1f, 1f), 0.5f),
+                    new GradientColorKey(Color.cyan, 1f)
+                },
+                new GradientAlphaKey[]
+                {
+                    new GradientAlphaKey(1f, 0f),
+                    new GradientAlphaKey(1f, 0.8f),
+                    new GradientAlphaKey(0.5f, 1f)
+                }
+            );
+            return gradient;
+        }
+
+        /// <summary>
+        /// Create the default gradient for prediction trajectory (yellow-orange).
+        /// </summary>
+        private static Gradient CreatePredictionGradient()
+        {
+            var gradient = new Gradient();
+            gradient.SetKeys(
+                new GradientColorKey[]
+                {
+                    new GradientColorKey(Color.yellow, 0f),
+                    new GradientColorKey(new Color(1f, 0.5f, 0f), 1f)
+                },
+                new GradientAlphaKey[]
+                {
+                    new GradientAlphaKey(0.8f, 0f),
+                    new GradientAlphaKey(0.3f, 1f)
+                }
+            );
+            return gradient;
+        }
+
+        /// <summary>
+        /// Helper to set a gradient on a SerializedProperty.
+        /// </summary>
+        private static void SetSerializedGradient(SerializedObject so, string propertyName, Gradient gradient)
+        {
+            var prop = so.FindProperty(propertyName);
+            if (prop != null)
+            {
+                prop.gradientValue = gradient;
+            }
+        }
+    }
+}

--- a/Assets/Editor/TrajectoryLineGenerator.cs.meta
+++ b/Assets/Editor/TrajectoryLineGenerator.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: e8d551726f4674a8098712baf92fc3fd

--- a/Assets/Scripts/Visualization/TrajectoryRenderer.cs
+++ b/Assets/Scripts/Visualization/TrajectoryRenderer.cs
@@ -1,0 +1,573 @@
+// ABOUTME: Renders golf ball trajectory as a visible line using LineRenderer.
+// ABOUTME: Supports actual and predicted paths with quality tier adjustments.
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using OpenRange.Physics;
+
+namespace OpenRange.Visualization
+{
+    /// <summary>
+    /// Renders the ball flight trajectory as a visible line.
+    /// Supports showing actual flight path, predicted path, or both.
+    /// Integrates with the quality tier system for performance optimization.
+    /// </summary>
+    public class TrajectoryRenderer : MonoBehaviour
+    {
+        /// <summary>
+        /// Display mode for trajectory visualization.
+        /// </summary>
+        public enum DisplayMode
+        {
+            /// <summary>Show only the actual flight path.</summary>
+            Actual,
+            /// <summary>Show only the predicted path (before shot lands).</summary>
+            Predicted,
+            /// <summary>Show both predicted and actual paths.</summary>
+            Both
+        }
+
+        [Header("Line Renderer References")]
+        [SerializeField] private LineRenderer _lineRenderer;
+        [SerializeField] private LineRenderer _predictionLineRenderer;
+
+        [Header("Display Settings")]
+        [SerializeField] private DisplayMode _displayMode = DisplayMode.Actual;
+        [SerializeField] private float _lineWidthStart = 0.05f;
+        [SerializeField] private float _lineWidthEnd = 0.01f;
+
+        [Header("Color Settings")]
+        [SerializeField] private Gradient _actualColorGradient;
+        [SerializeField] private Gradient _predictionColorGradient;
+
+        [Header("Quality Settings")]
+        [SerializeField] private int _vertexCountHigh = 100;
+        [SerializeField] private int _vertexCountMedium = 50;
+        [SerializeField] private int _vertexCountLow = 20;
+
+        [Header("Coordinate Conversion")]
+        [SerializeField] private float _yardsToUnits = 0.9144f;
+        [SerializeField] private float _feetToUnits = 0.3048f;
+        [SerializeField] private Vector3 _originOffset = Vector3.zero;
+
+        private QualityTier _currentQualityTier = QualityTier.High;
+        private ShotResult _currentShot;
+        private Coroutine _fadeCoroutine;
+        private bool _isVisible;
+        private bool _isPredictionVisible;
+
+        /// <summary>
+        /// Current display mode.
+        /// </summary>
+        public DisplayMode CurrentDisplayMode
+        {
+            get => _displayMode;
+            set => _displayMode = value;
+        }
+
+        /// <summary>
+        /// Whether the trajectory line is currently visible.
+        /// </summary>
+        public bool IsVisible => _isVisible;
+
+        /// <summary>
+        /// Whether the prediction line is currently visible.
+        /// </summary>
+        public bool IsPredictionVisible => _isPredictionVisible;
+
+        /// <summary>
+        /// Current quality tier affecting vertex count.
+        /// </summary>
+        public QualityTier CurrentQualityTier => _currentQualityTier;
+
+        /// <summary>
+        /// The main line renderer reference.
+        /// </summary>
+        public LineRenderer LineRenderer => _lineRenderer;
+
+        /// <summary>
+        /// The prediction line renderer reference.
+        /// </summary>
+        public LineRenderer PredictionLineRenderer => _predictionLineRenderer;
+
+        /// <summary>
+        /// Gets the current vertex count based on quality tier.
+        /// </summary>
+        public int CurrentVertexCount
+        {
+            get
+            {
+                return _currentQualityTier switch
+                {
+                    QualityTier.High => _vertexCountHigh,
+                    QualityTier.Medium => _vertexCountMedium,
+                    QualityTier.Low => _vertexCountLow,
+                    _ => _vertexCountMedium
+                };
+            }
+        }
+
+        /// <summary>
+        /// The origin offset for coordinate conversion.
+        /// </summary>
+        public Vector3 OriginOffset
+        {
+            get => _originOffset;
+            set => _originOffset = value;
+        }
+
+        private void Awake()
+        {
+            InitializeComponents();
+            InitializeDefaultGradients();
+        }
+
+        /// <summary>
+        /// Initialize component references if not set in inspector.
+        /// </summary>
+        private void InitializeComponents()
+        {
+            if (_lineRenderer == null)
+            {
+                _lineRenderer = GetComponent<LineRenderer>();
+            }
+
+            // Hide lines by default
+            if (_lineRenderer != null)
+            {
+                _lineRenderer.enabled = false;
+            }
+
+            if (_predictionLineRenderer != null)
+            {
+                _predictionLineRenderer.enabled = false;
+            }
+        }
+
+        /// <summary>
+        /// Initialize default color gradients if not set.
+        /// </summary>
+        private void InitializeDefaultGradients()
+        {
+            if (_actualColorGradient == null || _actualColorGradient.colorKeys.Length == 0)
+            {
+                _actualColorGradient = CreateDefaultActualGradient();
+            }
+
+            if (_predictionColorGradient == null || _predictionColorGradient.colorKeys.Length == 0)
+            {
+                _predictionColorGradient = CreateDefaultPredictionGradient();
+            }
+        }
+
+        /// <summary>
+        /// Create the default gradient for actual trajectory (white to cyan).
+        /// </summary>
+        private Gradient CreateDefaultActualGradient()
+        {
+            var gradient = new Gradient();
+            gradient.SetKeys(
+                new GradientColorKey[]
+                {
+                    new GradientColorKey(Color.white, 0f),
+                    new GradientColorKey(new Color(0.5f, 1f, 1f), 0.5f),
+                    new GradientColorKey(Color.cyan, 1f)
+                },
+                new GradientAlphaKey[]
+                {
+                    new GradientAlphaKey(1f, 0f),
+                    new GradientAlphaKey(1f, 0.8f),
+                    new GradientAlphaKey(0.5f, 1f)
+                }
+            );
+            return gradient;
+        }
+
+        /// <summary>
+        /// Create the default gradient for prediction trajectory (yellow-orange).
+        /// </summary>
+        private Gradient CreateDefaultPredictionGradient()
+        {
+            var gradient = new Gradient();
+            gradient.SetKeys(
+                new GradientColorKey[]
+                {
+                    new GradientColorKey(Color.yellow, 0f),
+                    new GradientColorKey(new Color(1f, 0.5f, 0f), 1f)
+                },
+                new GradientAlphaKey[]
+                {
+                    new GradientAlphaKey(0.8f, 0f),
+                    new GradientAlphaKey(0.3f, 1f)
+                }
+            );
+            return gradient;
+        }
+
+        /// <summary>
+        /// Show the actual trajectory from shot result.
+        /// </summary>
+        /// <param name="result">The shot result containing trajectory data.</param>
+        public void ShowTrajectory(ShotResult result)
+        {
+            if (result == null || result.Trajectory == null || result.Trajectory.Count == 0)
+            {
+                Debug.LogWarning("TrajectoryRenderer: Cannot show trajectory with null or empty data");
+                return;
+            }
+
+            // Cancel any fade in progress
+            StopFadeCoroutine();
+
+            _currentShot = result;
+
+            if (_lineRenderer != null)
+            {
+                var positions = SampleTrajectoryPoints(result.Trajectory);
+                ApplyPositionsToLineRenderer(_lineRenderer, positions, _actualColorGradient);
+                _lineRenderer.enabled = true;
+                _isVisible = true;
+            }
+        }
+
+        /// <summary>
+        /// Show predicted trajectory path (different visual style).
+        /// </summary>
+        /// <param name="result">The shot result containing predicted trajectory.</param>
+        public void ShowPrediction(ShotResult result)
+        {
+            if (result == null || result.Trajectory == null || result.Trajectory.Count == 0)
+            {
+                Debug.LogWarning("TrajectoryRenderer: Cannot show prediction with null or empty data");
+                return;
+            }
+
+            _currentShot = result;
+
+            // Use prediction line renderer if available, otherwise use main line
+            var lineRenderer = _predictionLineRenderer != null ? _predictionLineRenderer : _lineRenderer;
+
+            if (lineRenderer != null)
+            {
+                var positions = SampleTrajectoryPoints(result.Trajectory);
+                ApplyPositionsToLineRenderer(lineRenderer, positions, _predictionColorGradient);
+                lineRenderer.enabled = true;
+
+                if (_predictionLineRenderer != null)
+                {
+                    _isPredictionVisible = true;
+                }
+                else
+                {
+                    _isVisible = true;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Hide the trajectory immediately.
+        /// </summary>
+        public void Hide()
+        {
+            StopFadeCoroutine();
+
+            if (_lineRenderer != null)
+            {
+                _lineRenderer.enabled = false;
+            }
+
+            if (_predictionLineRenderer != null)
+            {
+                _predictionLineRenderer.enabled = false;
+            }
+
+            _isVisible = false;
+            _isPredictionVisible = false;
+        }
+
+        /// <summary>
+        /// Hide only the prediction line.
+        /// </summary>
+        public void HidePrediction()
+        {
+            if (_predictionLineRenderer != null)
+            {
+                _predictionLineRenderer.enabled = false;
+            }
+
+            _isPredictionVisible = false;
+        }
+
+        /// <summary>
+        /// Fade out the trajectory over a duration.
+        /// </summary>
+        /// <param name="duration">Duration of the fade in seconds.</param>
+        public void FadeOut(float duration)
+        {
+            if (!_isVisible && !_isPredictionVisible)
+            {
+                return;
+            }
+
+            StopFadeCoroutine();
+            _fadeCoroutine = StartCoroutine(FadeOutCoroutine(duration));
+        }
+
+        /// <summary>
+        /// Coroutine to fade out the trajectory line.
+        /// </summary>
+        private IEnumerator FadeOutCoroutine(float duration)
+        {
+            if (duration <= 0f)
+            {
+                Hide();
+                yield break;
+            }
+
+            float elapsed = 0f;
+            float startAlpha = 1f;
+
+            // Store original gradients
+            Gradient originalActualGradient = _lineRenderer != null ? CloneGradient(_lineRenderer.colorGradient) : null;
+            Gradient originalPredictionGradient = _predictionLineRenderer != null ? CloneGradient(_predictionLineRenderer.colorGradient) : null;
+
+            while (elapsed < duration)
+            {
+                elapsed += Time.deltaTime;
+                float t = elapsed / duration;
+                float alpha = Mathf.Lerp(startAlpha, 0f, t);
+
+                // Apply faded gradient to main line
+                if (_lineRenderer != null && _isVisible && originalActualGradient != null)
+                {
+                    var fadedGradient = CreateFadedGradient(originalActualGradient, alpha);
+                    _lineRenderer.colorGradient = fadedGradient;
+                }
+
+                // Apply faded gradient to prediction line
+                if (_predictionLineRenderer != null && _isPredictionVisible && originalPredictionGradient != null)
+                {
+                    var fadedGradient = CreateFadedGradient(originalPredictionGradient, alpha);
+                    _predictionLineRenderer.colorGradient = fadedGradient;
+                }
+
+                yield return null;
+            }
+
+            Hide();
+
+            // Restore original gradients after hiding
+            if (_lineRenderer != null && originalActualGradient != null)
+            {
+                _lineRenderer.colorGradient = originalActualGradient;
+            }
+
+            if (_predictionLineRenderer != null && originalPredictionGradient != null)
+            {
+                _predictionLineRenderer.colorGradient = originalPredictionGradient;
+            }
+
+            _fadeCoroutine = null;
+        }
+
+        /// <summary>
+        /// Clone a gradient.
+        /// </summary>
+        private Gradient CloneGradient(Gradient original)
+        {
+            var clone = new Gradient();
+            clone.SetKeys(original.colorKeys, original.alphaKeys);
+            return clone;
+        }
+
+        /// <summary>
+        /// Create a gradient with adjusted alpha.
+        /// </summary>
+        private Gradient CreateFadedGradient(Gradient original, float alphaMultiplier)
+        {
+            var faded = new Gradient();
+
+            var alphaKeys = new GradientAlphaKey[original.alphaKeys.Length];
+            for (int i = 0; i < original.alphaKeys.Length; i++)
+            {
+                alphaKeys[i] = new GradientAlphaKey(
+                    original.alphaKeys[i].alpha * alphaMultiplier,
+                    original.alphaKeys[i].time
+                );
+            }
+
+            faded.SetKeys(original.colorKeys, alphaKeys);
+            return faded;
+        }
+
+        /// <summary>
+        /// Stop any fade coroutine in progress.
+        /// </summary>
+        private void StopFadeCoroutine()
+        {
+            if (_fadeCoroutine != null)
+            {
+                StopCoroutine(_fadeCoroutine);
+                _fadeCoroutine = null;
+            }
+        }
+
+        /// <summary>
+        /// Set the quality tier which affects vertex count.
+        /// </summary>
+        /// <param name="tier">The quality tier to apply.</param>
+        public void SetQualityTier(QualityTier tier)
+        {
+            _currentQualityTier = tier;
+
+            // Re-render current trajectory if visible
+            if (_isVisible && _currentShot != null)
+            {
+                ShowTrajectory(_currentShot);
+            }
+        }
+
+        /// <summary>
+        /// Sample trajectory points to create a smooth line with target vertex count.
+        /// </summary>
+        private Vector3[] SampleTrajectoryPoints(List<TrajectoryPoint> trajectory)
+        {
+            int targetCount = CurrentVertexCount;
+
+            if (trajectory.Count <= targetCount)
+            {
+                // No need to resample, use all points
+                return ConvertToWorldPositions(trajectory);
+            }
+
+            // Resample to target count
+            var positions = new Vector3[targetCount];
+            float step = (float)(trajectory.Count - 1) / (targetCount - 1);
+
+            for (int i = 0; i < targetCount; i++)
+            {
+                float index = i * step;
+                int lowIndex = Mathf.FloorToInt(index);
+                int highIndex = Mathf.CeilToInt(index);
+                highIndex = Mathf.Min(highIndex, trajectory.Count - 1);
+
+                if (lowIndex == highIndex)
+                {
+                    positions[i] = TrajectoryPointToWorldPosition(trajectory[lowIndex]);
+                }
+                else
+                {
+                    float t = index - lowIndex;
+                    Vector3 lowPos = TrajectoryPointToWorldPosition(trajectory[lowIndex]);
+                    Vector3 highPos = TrajectoryPointToWorldPosition(trajectory[highIndex]);
+                    positions[i] = Vector3.Lerp(lowPos, highPos, t);
+                }
+            }
+
+            return positions;
+        }
+
+        /// <summary>
+        /// Convert all trajectory points to world positions.
+        /// </summary>
+        private Vector3[] ConvertToWorldPositions(List<TrajectoryPoint> trajectory)
+        {
+            var positions = new Vector3[trajectory.Count];
+            for (int i = 0; i < trajectory.Count; i++)
+            {
+                positions[i] = TrajectoryPointToWorldPosition(trajectory[i]);
+            }
+            return positions;
+        }
+
+        /// <summary>
+        /// Convert a trajectory point to world position.
+        /// Trajectory uses: X = forward (yards), Y = height (feet), Z = lateral (yards)
+        /// </summary>
+        private Vector3 TrajectoryPointToWorldPosition(TrajectoryPoint point)
+        {
+            return new Vector3(
+                point.Position.x * _yardsToUnits + _originOffset.x,
+                point.Position.y * _feetToUnits + _originOffset.y,
+                point.Position.z * _yardsToUnits + _originOffset.z
+            );
+        }
+
+        /// <summary>
+        /// Apply positions to a line renderer.
+        /// </summary>
+        private void ApplyPositionsToLineRenderer(LineRenderer lineRenderer, Vector3[] positions, Gradient colorGradient)
+        {
+            lineRenderer.positionCount = positions.Length;
+            lineRenderer.SetPositions(positions);
+            lineRenderer.startWidth = _lineWidthStart;
+            lineRenderer.endWidth = _lineWidthEnd;
+            lineRenderer.colorGradient = colorGradient;
+        }
+
+        /// <summary>
+        /// Set the actual color gradient.
+        /// </summary>
+        public void SetActualColorGradient(Gradient gradient)
+        {
+            _actualColorGradient = gradient;
+        }
+
+        /// <summary>
+        /// Set the prediction color gradient.
+        /// </summary>
+        public void SetPredictionColorGradient(Gradient gradient)
+        {
+            _predictionColorGradient = gradient;
+        }
+
+        /// <summary>
+        /// Set the line renderer reference.
+        /// </summary>
+        public void SetLineRenderer(LineRenderer lineRenderer)
+        {
+            _lineRenderer = lineRenderer;
+        }
+
+        /// <summary>
+        /// Set the prediction line renderer reference.
+        /// </summary>
+        public void SetPredictionLineRenderer(LineRenderer lineRenderer)
+        {
+            _predictionLineRenderer = lineRenderer;
+        }
+
+        /// <summary>
+        /// Get the world position at a normalized progress (0-1) along the trajectory.
+        /// </summary>
+        /// <param name="progress">Normalized progress (0 = start, 1 = end).</param>
+        /// <returns>World position at that point.</returns>
+        public Vector3 GetPositionAtProgress(float progress)
+        {
+            if (_currentShot == null || _currentShot.Trajectory == null || _currentShot.Trajectory.Count == 0)
+            {
+                return _originOffset;
+            }
+
+            var trajectory = _currentShot.Trajectory;
+            progress = Mathf.Clamp01(progress);
+
+            float index = progress * (trajectory.Count - 1);
+            int lowIndex = Mathf.FloorToInt(index);
+            int highIndex = Mathf.CeilToInt(index);
+            highIndex = Mathf.Min(highIndex, trajectory.Count - 1);
+
+            if (lowIndex == highIndex)
+            {
+                return TrajectoryPointToWorldPosition(trajectory[lowIndex]);
+            }
+
+            float t = index - lowIndex;
+            Vector3 lowPos = TrajectoryPointToWorldPosition(trajectory[lowIndex]);
+            Vector3 highPos = TrajectoryPointToWorldPosition(trajectory[highIndex]);
+            return Vector3.Lerp(lowPos, highPos, t);
+        }
+    }
+}

--- a/Assets/Scripts/Visualization/TrajectoryRenderer.cs.meta
+++ b/Assets/Scripts/Visualization/TrajectoryRenderer.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 0f9a58b64873a4af6b3ccab1527ae580

--- a/Assets/Tests/EditMode/TrajectoryRendererTests.cs
+++ b/Assets/Tests/EditMode/TrajectoryRendererTests.cs
@@ -1,0 +1,758 @@
+// ABOUTME: Unit tests for the TrajectoryRenderer component.
+// ABOUTME: Tests line rendering, quality tiers, fade out, and coordinate conversion.
+
+using NUnit.Framework;
+using UnityEngine;
+using OpenRange.Visualization;
+using OpenRange.Physics;
+using System.Collections.Generic;
+
+namespace OpenRange.Tests.EditMode
+{
+    [TestFixture]
+    public class TrajectoryRendererTests
+    {
+        private GameObject _testObject;
+        private TrajectoryRenderer _trajectoryRenderer;
+        private LineRenderer _lineRenderer;
+        private LineRenderer _predictionLineRenderer;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _testObject = new GameObject("TestTrajectoryLine");
+            _trajectoryRenderer = _testObject.AddComponent<TrajectoryRenderer>();
+
+            // Create and attach main line renderer
+            _lineRenderer = _testObject.AddComponent<LineRenderer>();
+            _lineRenderer.enabled = false;
+
+            // Create prediction line renderer as child
+            var predictionGo = new GameObject("PredictionLine");
+            predictionGo.transform.SetParent(_testObject.transform);
+            _predictionLineRenderer = predictionGo.AddComponent<LineRenderer>();
+            _predictionLineRenderer.enabled = false;
+
+            // Use reflection to set private serialized fields since we're in EditMode
+            SetPrivateField(_trajectoryRenderer, "_lineRenderer", _lineRenderer);
+            SetPrivateField(_trajectoryRenderer, "_predictionLineRenderer", _predictionLineRenderer);
+            SetPrivateField(_trajectoryRenderer, "_vertexCountHigh", 100);
+            SetPrivateField(_trajectoryRenderer, "_vertexCountMedium", 50);
+            SetPrivateField(_trajectoryRenderer, "_vertexCountLow", 20);
+            SetPrivateField(_trajectoryRenderer, "_yardsToUnits", 0.9144f);
+            SetPrivateField(_trajectoryRenderer, "_feetToUnits", 0.3048f);
+            SetPrivateField(_trajectoryRenderer, "_lineWidthStart", 0.05f);
+            SetPrivateField(_trajectoryRenderer, "_lineWidthEnd", 0.01f);
+
+            // Create default gradients
+            var actualGradient = CreateActualGradient();
+            var predictionGradient = CreatePredictionGradient();
+            SetPrivateField(_trajectoryRenderer, "_actualColorGradient", actualGradient);
+            SetPrivateField(_trajectoryRenderer, "_predictionColorGradient", predictionGradient);
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            if (_testObject != null)
+            {
+                Object.DestroyImmediate(_testObject);
+            }
+        }
+
+        #region ShowTrajectory Tests
+
+        [Test]
+        public void ShowTrajectory_ValidResult_EnablesLineRenderer()
+        {
+            // Arrange
+            var result = CreateTestShotResult(10);
+
+            // Act
+            _trajectoryRenderer.ShowTrajectory(result);
+
+            // Assert
+            Assert.IsTrue(_lineRenderer.enabled);
+            Assert.IsTrue(_trajectoryRenderer.IsVisible);
+        }
+
+        [Test]
+        public void ShowTrajectory_ValidResult_SetsPositionCount()
+        {
+            // Arrange
+            var result = CreateTestShotResult(10);
+
+            // Act
+            _trajectoryRenderer.ShowTrajectory(result);
+
+            // Assert
+            Assert.AreEqual(10, _lineRenderer.positionCount);
+        }
+
+        [Test]
+        public void ShowTrajectory_NullResult_DoesNotThrow()
+        {
+            // Act & Assert
+            Assert.DoesNotThrow(() => _trajectoryRenderer.ShowTrajectory(null));
+            Assert.IsFalse(_trajectoryRenderer.IsVisible);
+        }
+
+        [Test]
+        public void ShowTrajectory_EmptyTrajectory_DoesNotThrow()
+        {
+            // Arrange
+            var result = new ShotResult { Trajectory = new List<TrajectoryPoint>() };
+
+            // Act & Assert
+            Assert.DoesNotThrow(() => _trajectoryRenderer.ShowTrajectory(result));
+            Assert.IsFalse(_trajectoryRenderer.IsVisible);
+        }
+
+        [Test]
+        public void ShowTrajectory_LargeTrajectory_ResamplesPoints()
+        {
+            // Arrange - Create trajectory with more points than vertex count
+            var result = CreateTestShotResult(200);
+            _trajectoryRenderer.SetQualityTier(QualityTier.High); // 100 vertices
+
+            // Act
+            _trajectoryRenderer.ShowTrajectory(result);
+
+            // Assert - Should be resampled to 100 points
+            Assert.AreEqual(100, _lineRenderer.positionCount);
+        }
+
+        [Test]
+        public void ShowTrajectory_SmallTrajectory_UsesAllPoints()
+        {
+            // Arrange - Create trajectory with fewer points than vertex count
+            var result = CreateTestShotResult(25);
+            _trajectoryRenderer.SetQualityTier(QualityTier.High); // 100 vertices
+
+            // Act
+            _trajectoryRenderer.ShowTrajectory(result);
+
+            // Assert - Should use all 25 points
+            Assert.AreEqual(25, _lineRenderer.positionCount);
+        }
+
+        [Test]
+        public void ShowTrajectory_SetsLineWidths()
+        {
+            // Arrange
+            var result = CreateTestShotResult(10);
+
+            // Act
+            _trajectoryRenderer.ShowTrajectory(result);
+
+            // Assert
+            Assert.AreEqual(0.05f, _lineRenderer.startWidth);
+            Assert.AreEqual(0.01f, _lineRenderer.endWidth);
+        }
+
+        [Test]
+        public void ShowTrajectory_ConvertsCoordinatesCorrectly()
+        {
+            // Arrange - Create trajectory with known positions
+            var result = new ShotResult
+            {
+                Trajectory = new List<TrajectoryPoint>
+                {
+                    new TrajectoryPoint(0f, new Vector3(0f, 0f, 0f), Phase.Flight),
+                    new TrajectoryPoint(1f, new Vector3(100f, 32.8084f, 10f), Phase.Flight) // 100 yards forward, ~10 meters high, 10 yards right
+                }
+            };
+
+            // Act
+            _trajectoryRenderer.ShowTrajectory(result);
+
+            // Assert
+            Vector3[] positions = new Vector3[2];
+            _lineRenderer.GetPositions(positions);
+
+            // First point should be at origin (with offset)
+            Assert.AreEqual(0f, positions[0].x, 0.001f);
+            Assert.AreEqual(0f, positions[0].y, 0.001f);
+            Assert.AreEqual(0f, positions[0].z, 0.001f);
+
+            // Second point: X = 100 yards * 0.9144 = 91.44m, Y = 32.8084 feet * 0.3048 = 10m, Z = 10 yards * 0.9144 = 9.144m
+            Assert.AreEqual(91.44f, positions[1].x, 0.01f);
+            Assert.AreEqual(10f, positions[1].y, 0.01f);
+            Assert.AreEqual(9.144f, positions[1].z, 0.01f);
+        }
+
+        [Test]
+        public void ShowTrajectory_AppliesOriginOffset()
+        {
+            // Arrange
+            _trajectoryRenderer.OriginOffset = new Vector3(5f, 1f, 2f);
+            var result = new ShotResult
+            {
+                Trajectory = new List<TrajectoryPoint>
+                {
+                    new TrajectoryPoint(0f, new Vector3(0f, 0f, 0f), Phase.Flight)
+                }
+            };
+
+            // Act
+            _trajectoryRenderer.ShowTrajectory(result);
+
+            // Assert
+            Vector3[] positions = new Vector3[1];
+            _lineRenderer.GetPositions(positions);
+
+            Assert.AreEqual(5f, positions[0].x, 0.001f);
+            Assert.AreEqual(1f, positions[0].y, 0.001f);
+            Assert.AreEqual(2f, positions[0].z, 0.001f);
+        }
+
+        #endregion
+
+        #region ShowPrediction Tests
+
+        [Test]
+        public void ShowPrediction_ValidResult_EnablesPredictionRenderer()
+        {
+            // Arrange
+            var result = CreateTestShotResult(10);
+
+            // Act
+            _trajectoryRenderer.ShowPrediction(result);
+
+            // Assert
+            Assert.IsTrue(_predictionLineRenderer.enabled);
+            Assert.IsTrue(_trajectoryRenderer.IsPredictionVisible);
+        }
+
+        [Test]
+        public void ShowPrediction_NullResult_DoesNotThrow()
+        {
+            // Act & Assert
+            Assert.DoesNotThrow(() => _trajectoryRenderer.ShowPrediction(null));
+            Assert.IsFalse(_trajectoryRenderer.IsPredictionVisible);
+        }
+
+        [Test]
+        public void ShowPrediction_WithNullPredictionRenderer_UsesMainRenderer()
+        {
+            // Arrange
+            SetPrivateField(_trajectoryRenderer, "_predictionLineRenderer", null);
+            var result = CreateTestShotResult(10);
+
+            // Act
+            _trajectoryRenderer.ShowPrediction(result);
+
+            // Assert - Should use main line renderer
+            Assert.IsTrue(_lineRenderer.enabled);
+            Assert.IsTrue(_trajectoryRenderer.IsVisible);
+        }
+
+        #endregion
+
+        #region Hide Tests
+
+        [Test]
+        public void Hide_DisablesLineRenderer()
+        {
+            // Arrange
+            _trajectoryRenderer.ShowTrajectory(CreateTestShotResult(10));
+            Assert.IsTrue(_trajectoryRenderer.IsVisible);
+
+            // Act
+            _trajectoryRenderer.Hide();
+
+            // Assert
+            Assert.IsFalse(_lineRenderer.enabled);
+            Assert.IsFalse(_trajectoryRenderer.IsVisible);
+        }
+
+        [Test]
+        public void Hide_DisablesPredictionRenderer()
+        {
+            // Arrange
+            _trajectoryRenderer.ShowPrediction(CreateTestShotResult(10));
+            Assert.IsTrue(_trajectoryRenderer.IsPredictionVisible);
+
+            // Act
+            _trajectoryRenderer.Hide();
+
+            // Assert
+            Assert.IsFalse(_predictionLineRenderer.enabled);
+            Assert.IsFalse(_trajectoryRenderer.IsPredictionVisible);
+        }
+
+        [Test]
+        public void Hide_WhenAlreadyHidden_DoesNotThrow()
+        {
+            // Act & Assert
+            Assert.DoesNotThrow(() => _trajectoryRenderer.Hide());
+        }
+
+        [Test]
+        public void HidePrediction_HidesOnlyPredictionLine()
+        {
+            // Arrange
+            _trajectoryRenderer.ShowTrajectory(CreateTestShotResult(10));
+            _trajectoryRenderer.ShowPrediction(CreateTestShotResult(10));
+
+            // Act
+            _trajectoryRenderer.HidePrediction();
+
+            // Assert
+            Assert.IsTrue(_trajectoryRenderer.IsVisible); // Main still visible
+            Assert.IsFalse(_trajectoryRenderer.IsPredictionVisible);
+        }
+
+        #endregion
+
+        #region Quality Tier Tests
+
+        [Test]
+        public void SetQualityTier_High_SetsCorrectVertexCount()
+        {
+            // Act
+            _trajectoryRenderer.SetQualityTier(QualityTier.High);
+
+            // Assert
+            Assert.AreEqual(QualityTier.High, _trajectoryRenderer.CurrentQualityTier);
+            Assert.AreEqual(100, _trajectoryRenderer.CurrentVertexCount);
+        }
+
+        [Test]
+        public void SetQualityTier_Medium_SetsCorrectVertexCount()
+        {
+            // Act
+            _trajectoryRenderer.SetQualityTier(QualityTier.Medium);
+
+            // Assert
+            Assert.AreEqual(QualityTier.Medium, _trajectoryRenderer.CurrentQualityTier);
+            Assert.AreEqual(50, _trajectoryRenderer.CurrentVertexCount);
+        }
+
+        [Test]
+        public void SetQualityTier_Low_SetsCorrectVertexCount()
+        {
+            // Act
+            _trajectoryRenderer.SetQualityTier(QualityTier.Low);
+
+            // Assert
+            Assert.AreEqual(QualityTier.Low, _trajectoryRenderer.CurrentQualityTier);
+            Assert.AreEqual(20, _trajectoryRenderer.CurrentVertexCount);
+        }
+
+        [Test]
+        public void SetQualityTier_WhileVisible_ReRendersWithNewVertexCount()
+        {
+            // Arrange
+            _trajectoryRenderer.SetQualityTier(QualityTier.High);
+            var result = CreateTestShotResult(150);
+            _trajectoryRenderer.ShowTrajectory(result);
+            Assert.AreEqual(100, _lineRenderer.positionCount);
+
+            // Act
+            _trajectoryRenderer.SetQualityTier(QualityTier.Low);
+
+            // Assert
+            Assert.AreEqual(20, _lineRenderer.positionCount);
+        }
+
+        [Test]
+        public void CurrentQualityTier_DefaultsToHigh()
+        {
+            // Assert
+            Assert.AreEqual(QualityTier.High, _trajectoryRenderer.CurrentQualityTier);
+        }
+
+        #endregion
+
+        #region DisplayMode Tests
+
+        [Test]
+        public void CurrentDisplayMode_DefaultsToActual()
+        {
+            // Assert
+            Assert.AreEqual(TrajectoryRenderer.DisplayMode.Actual, _trajectoryRenderer.CurrentDisplayMode);
+        }
+
+        [Test]
+        public void CurrentDisplayMode_CanBeSet()
+        {
+            // Act
+            _trajectoryRenderer.CurrentDisplayMode = TrajectoryRenderer.DisplayMode.Predicted;
+
+            // Assert
+            Assert.AreEqual(TrajectoryRenderer.DisplayMode.Predicted, _trajectoryRenderer.CurrentDisplayMode);
+        }
+
+        [Test]
+        public void CurrentDisplayMode_CanBeSetToBoth()
+        {
+            // Act
+            _trajectoryRenderer.CurrentDisplayMode = TrajectoryRenderer.DisplayMode.Both;
+
+            // Assert
+            Assert.AreEqual(TrajectoryRenderer.DisplayMode.Both, _trajectoryRenderer.CurrentDisplayMode);
+        }
+
+        #endregion
+
+        #region GetPositionAtProgress Tests
+
+        [Test]
+        public void GetPositionAtProgress_Zero_ReturnsStartPosition()
+        {
+            // Arrange
+            var result = new ShotResult
+            {
+                Trajectory = new List<TrajectoryPoint>
+                {
+                    new TrajectoryPoint(0f, new Vector3(0f, 0f, 0f), Phase.Flight),
+                    new TrajectoryPoint(1f, new Vector3(100f, 32.8084f, 0f), Phase.Flight)
+                }
+            };
+            _trajectoryRenderer.ShowTrajectory(result);
+
+            // Act
+            Vector3 pos = _trajectoryRenderer.GetPositionAtProgress(0f);
+
+            // Assert
+            Assert.AreEqual(0f, pos.x, 0.001f);
+            Assert.AreEqual(0f, pos.y, 0.001f);
+        }
+
+        [Test]
+        public void GetPositionAtProgress_One_ReturnsEndPosition()
+        {
+            // Arrange
+            var result = new ShotResult
+            {
+                Trajectory = new List<TrajectoryPoint>
+                {
+                    new TrajectoryPoint(0f, new Vector3(0f, 0f, 0f), Phase.Flight),
+                    new TrajectoryPoint(1f, new Vector3(100f, 32.8084f, 0f), Phase.Flight)
+                }
+            };
+            _trajectoryRenderer.ShowTrajectory(result);
+
+            // Act
+            Vector3 pos = _trajectoryRenderer.GetPositionAtProgress(1f);
+
+            // Assert - 100 yards = 91.44m
+            Assert.AreEqual(91.44f, pos.x, 0.01f);
+        }
+
+        [Test]
+        public void GetPositionAtProgress_Half_ReturnsInterpolatedPosition()
+        {
+            // Arrange
+            var result = new ShotResult
+            {
+                Trajectory = new List<TrajectoryPoint>
+                {
+                    new TrajectoryPoint(0f, new Vector3(0f, 0f, 0f), Phase.Flight),
+                    new TrajectoryPoint(1f, new Vector3(100f, 0f, 0f), Phase.Flight)
+                }
+            };
+            _trajectoryRenderer.ShowTrajectory(result);
+
+            // Act
+            Vector3 pos = _trajectoryRenderer.GetPositionAtProgress(0.5f);
+
+            // Assert - 50 yards = 45.72m
+            Assert.AreEqual(45.72f, pos.x, 0.01f);
+        }
+
+        [Test]
+        public void GetPositionAtProgress_NoShot_ReturnsOriginOffset()
+        {
+            // Arrange
+            _trajectoryRenderer.OriginOffset = new Vector3(1f, 2f, 3f);
+
+            // Act
+            Vector3 pos = _trajectoryRenderer.GetPositionAtProgress(0.5f);
+
+            // Assert
+            Assert.AreEqual(1f, pos.x);
+            Assert.AreEqual(2f, pos.y);
+            Assert.AreEqual(3f, pos.z);
+        }
+
+        [Test]
+        public void GetPositionAtProgress_NegativeProgress_ClampsToZero()
+        {
+            // Arrange
+            var result = new ShotResult
+            {
+                Trajectory = new List<TrajectoryPoint>
+                {
+                    new TrajectoryPoint(0f, new Vector3(0f, 0f, 0f), Phase.Flight),
+                    new TrajectoryPoint(1f, new Vector3(100f, 0f, 0f), Phase.Flight)
+                }
+            };
+            _trajectoryRenderer.ShowTrajectory(result);
+
+            // Act
+            Vector3 pos = _trajectoryRenderer.GetPositionAtProgress(-0.5f);
+
+            // Assert
+            Assert.AreEqual(0f, pos.x, 0.001f);
+        }
+
+        [Test]
+        public void GetPositionAtProgress_OverOne_ClampsToOne()
+        {
+            // Arrange
+            var result = new ShotResult
+            {
+                Trajectory = new List<TrajectoryPoint>
+                {
+                    new TrajectoryPoint(0f, new Vector3(0f, 0f, 0f), Phase.Flight),
+                    new TrajectoryPoint(1f, new Vector3(100f, 0f, 0f), Phase.Flight)
+                }
+            };
+            _trajectoryRenderer.ShowTrajectory(result);
+
+            // Act
+            Vector3 pos = _trajectoryRenderer.GetPositionAtProgress(1.5f);
+
+            // Assert - 100 yards = 91.44m
+            Assert.AreEqual(91.44f, pos.x, 0.01f);
+        }
+
+        #endregion
+
+        #region Property Tests
+
+        [Test]
+        public void LineRenderer_Property_ReturnsCorrectReference()
+        {
+            // Assert
+            Assert.AreEqual(_lineRenderer, _trajectoryRenderer.LineRenderer);
+        }
+
+        [Test]
+        public void PredictionLineRenderer_Property_ReturnsCorrectReference()
+        {
+            // Assert
+            Assert.AreEqual(_predictionLineRenderer, _trajectoryRenderer.PredictionLineRenderer);
+        }
+
+        [Test]
+        public void IsVisible_DefaultsFalse()
+        {
+            // Assert
+            Assert.IsFalse(_trajectoryRenderer.IsVisible);
+        }
+
+        [Test]
+        public void IsPredictionVisible_DefaultsFalse()
+        {
+            // Assert
+            Assert.IsFalse(_trajectoryRenderer.IsPredictionVisible);
+        }
+
+        [Test]
+        public void OriginOffset_CanBeSetAndGet()
+        {
+            // Arrange
+            var offset = new Vector3(10f, 5f, 3f);
+
+            // Act
+            _trajectoryRenderer.OriginOffset = offset;
+
+            // Assert
+            Assert.AreEqual(offset, _trajectoryRenderer.OriginOffset);
+        }
+
+        #endregion
+
+        #region Gradient Tests
+
+        [Test]
+        public void SetActualColorGradient_DoesNotThrow()
+        {
+            // Arrange
+            var gradient = new Gradient();
+
+            // Act & Assert
+            Assert.DoesNotThrow(() => _trajectoryRenderer.SetActualColorGradient(gradient));
+        }
+
+        [Test]
+        public void SetPredictionColorGradient_DoesNotThrow()
+        {
+            // Arrange
+            var gradient = new Gradient();
+
+            // Act & Assert
+            Assert.DoesNotThrow(() => _trajectoryRenderer.SetPredictionColorGradient(gradient));
+        }
+
+        #endregion
+
+        #region FadeOut Tests
+
+        [Test]
+        public void FadeOut_WhenNotVisible_DoesNotThrow()
+        {
+            // Act & Assert
+            Assert.DoesNotThrow(() => _trajectoryRenderer.FadeOut(1f));
+        }
+
+        [Test]
+        public void FadeOut_ZeroDuration_HidesImmediately()
+        {
+            // Arrange
+            _trajectoryRenderer.ShowTrajectory(CreateTestShotResult(10));
+            Assert.IsTrue(_trajectoryRenderer.IsVisible);
+
+            // Act
+            _trajectoryRenderer.FadeOut(0f);
+
+            // Assert - With zero duration, the coroutine calls Hide() before yield break,
+            // which executes synchronously, so IsVisible should be false
+            Assert.IsFalse(_trajectoryRenderer.IsVisible);
+        }
+
+        #endregion
+
+        #region Null Handling Tests
+
+        [Test]
+        public void ShowTrajectory_WithNullLineRenderer_DoesNotThrow()
+        {
+            // Arrange
+            SetPrivateField(_trajectoryRenderer, "_lineRenderer", null);
+
+            // Act & Assert
+            Assert.DoesNotThrow(() => _trajectoryRenderer.ShowTrajectory(CreateTestShotResult(10)));
+        }
+
+        [Test]
+        public void Hide_WithNullLineRenderers_DoesNotThrow()
+        {
+            // Arrange
+            SetPrivateField(_trajectoryRenderer, "_lineRenderer", null);
+            SetPrivateField(_trajectoryRenderer, "_predictionLineRenderer", null);
+
+            // Act & Assert
+            Assert.DoesNotThrow(() => _trajectoryRenderer.Hide());
+        }
+
+        [Test]
+        public void SetLineRenderer_SetsReference()
+        {
+            // Arrange
+            var newLineRenderer = _testObject.AddComponent<LineRenderer>();
+
+            // Act
+            _trajectoryRenderer.SetLineRenderer(newLineRenderer);
+
+            // Assert
+            Assert.AreEqual(newLineRenderer, _trajectoryRenderer.LineRenderer);
+        }
+
+        [Test]
+        public void SetPredictionLineRenderer_SetsReference()
+        {
+            // Arrange
+            var newLineRenderer = _testObject.AddComponent<LineRenderer>();
+
+            // Act
+            _trajectoryRenderer.SetPredictionLineRenderer(newLineRenderer);
+
+            // Assert
+            Assert.AreEqual(newLineRenderer, _trajectoryRenderer.PredictionLineRenderer);
+        }
+
+        #endregion
+
+        #region Helper Methods
+
+        /// <summary>
+        /// Helper to set private serialized fields via reflection for testing.
+        /// </summary>
+        private void SetPrivateField(object obj, string fieldName, object value)
+        {
+            var field = obj.GetType().GetField(fieldName,
+                System.Reflection.BindingFlags.NonPublic |
+                System.Reflection.BindingFlags.Instance);
+
+            if (field != null)
+            {
+                field.SetValue(obj, value);
+            }
+        }
+
+        /// <summary>
+        /// Create a test shot result with a simple trajectory.
+        /// </summary>
+        private ShotResult CreateTestShotResult(int pointCount)
+        {
+            var trajectory = new List<TrajectoryPoint>();
+            for (int i = 0; i < pointCount; i++)
+            {
+                float t = (float)i / (pointCount - 1);
+                float x = t * 200f; // 200 yards total
+                float y = 4f * t * (1f - t) * 100f; // Parabolic arc, max height ~100 feet
+                float z = t * 10f; // Slight right drift
+
+                trajectory.Add(new TrajectoryPoint(t * 5f, new Vector3(x, y, z), Phase.Flight));
+            }
+
+            return new ShotResult
+            {
+                Trajectory = trajectory,
+                CarryDistance = 180f,
+                TotalDistance = 200f,
+                MaxHeight = 100f,
+                FlightTime = 5f,
+                TotalTime = 6f
+            };
+        }
+
+        /// <summary>
+        /// Create the default gradient for actual trajectory.
+        /// </summary>
+        private Gradient CreateActualGradient()
+        {
+            var gradient = new Gradient();
+            gradient.SetKeys(
+                new GradientColorKey[]
+                {
+                    new GradientColorKey(Color.white, 0f),
+                    new GradientColorKey(Color.cyan, 1f)
+                },
+                new GradientAlphaKey[]
+                {
+                    new GradientAlphaKey(1f, 0f),
+                    new GradientAlphaKey(0.5f, 1f)
+                }
+            );
+            return gradient;
+        }
+
+        /// <summary>
+        /// Create the default gradient for prediction trajectory.
+        /// </summary>
+        private Gradient CreatePredictionGradient()
+        {
+            var gradient = new Gradient();
+            gradient.SetKeys(
+                new GradientColorKey[]
+                {
+                    new GradientColorKey(Color.yellow, 0f),
+                    new GradientColorKey(new Color(1f, 0.5f, 0f), 1f)
+                },
+                new GradientAlphaKey[]
+                {
+                    new GradientAlphaKey(0.8f, 0f),
+                    new GradientAlphaKey(0.3f, 1f)
+                }
+            );
+            return gradient;
+        }
+
+        #endregion
+    }
+}

--- a/Assets/Tests/EditMode/TrajectoryRendererTests.cs.meta
+++ b/Assets/Tests/EditMode/TrajectoryRendererTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 5b1a4ee43f60849659b2c78a95a16d38


### PR DESCRIPTION
## Summary

Implements the TrajectoryRenderer component for visualizing ball flight paths using Unity's LineRenderer (Prompt 8 from plan.md).

### Key Features

- **TrajectoryRenderer.cs** - MonoBehaviour that renders trajectory as visible lines
  - Display modes: Actual, Predicted, Both
  - Quality tiers: High (100 vertices), Medium (50), Low (20)
  - FadeOut animation with configurable duration
  - Coordinate conversion matching BallController (yards/feet to Unity units)
  - Color gradients for actual (white→cyan) and predicted (yellow→orange) paths
  - Methods: ShowTrajectory(), ShowPrediction(), Hide(), FadeOut(), SetQualityTier()

- **TrajectoryLineGenerator.cs** - Editor tool (OpenRange > Create Trajectory Line Prefab)
  - Creates TrajectoryLine.mat (URP Particles/Unlit with additive blending)
  - Creates PredictionLine.mat for predicted trajectory
  - Creates TrajectoryLine.prefab with configured LineRenderers

### Files Added

- `Assets/Scripts/Visualization/TrajectoryRenderer.cs`
- `Assets/Editor/TrajectoryLineGenerator.cs`
- `Assets/Tests/EditMode/TrajectoryRendererTests.cs` (43 tests)

### Test Plan

- [x] Line renders correctly from trajectory data with proper coordinate conversion
- [x] Quality tier changes vertex count (High=100, Medium=50, Low=20)
- [x] FadeOut animation works (tested zero duration sync behavior)
- [x] Show/Hide state management
- [x] DisplayMode switching (Actual/Predicted/Both)
- [x] GetPositionAtProgress interpolation
- [x] All 352 EditMode tests pass

Closes #12

🤖 Generated with [Claude Code](https://claude.com/claude-code)