### PR TITLE
feat(build): Add macOS code signing and notarization scripts

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -100,6 +100,14 @@ make build-app-dev # Development build (faster, debugging enabled)
 make build-release # Release build with version from git tag
 make package       # Create DMG for distribution
 
+# Code Signing (requires APPLE_DEVELOPER_ID, APPLE_ID, APPLE_TEAM_ID, APPLE_APP_PASSWORD)
+make sign          # Sign app bundle with Developer ID
+make notarize      # Submit for notarization and staple ticket
+make dmg           # Create signed DMG for distribution
+make release-macos # Full pipeline: build, sign, notarize, DMG
+make setup-signing # Setup keychain for CI (import certificates)
+make cleanup-signing # Remove CI keychain after build
+
 # Cleanup
 make clean         # Remove build artifacts and test results
 make clean-builds  # Remove only build outputs (keep test results)

--- a/Scripts/entitlements.plist
+++ b/Scripts/entitlements.plist
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!--
+ABOUTME: Entitlements for GC2 Connect macOS app bundle.
+ABOUTME: Required for IL2CPP, USB access, and loading external libraries.
+-->
+<plist version="1.0">
+<dict>
+    <!-- Required for IL2CPP runtime code generation -->
+    <key>com.apple.security.cs.allow-jit</key>
+    <true/>
+
+    <!-- Required for IL2CPP runtime memory management -->
+    <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+    <true/>
+
+    <!-- Required for loading libusb dynamic library -->
+    <key>com.apple.security.cs.disable-library-validation</key>
+    <true/>
+
+    <!-- Required for GC2 USB communication -->
+    <key>com.apple.security.device.usb</key>
+    <true/>
+
+    <!-- Hardened runtime is enabled, but we need these relaxations -->
+    <key>com.apple.security.cs.debugger</key>
+    <false/>
+</dict>
+</plist>

--- a/Scripts/setup_signing.sh
+++ b/Scripts/setup_signing.sh
@@ -1,0 +1,202 @@
+#!/bin/bash
+# ABOUTME: Setup script for code signing in CI environments.
+# ABOUTME: Imports certificates from base64 environment variables into a temporary keychain.
+
+set -e
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m' # No Color
+
+# Logging helpers
+log_step() {
+    echo ""
+    echo -e "${BLUE}==>${NC} ${GREEN}$1${NC}"
+}
+
+log_info() {
+    echo -e "    $1"
+}
+
+log_warning() {
+    echo -e "    ${YELLOW}Warning:${NC} $1"
+}
+
+log_error() {
+    echo -e "    ${RED}Error:${NC} $1"
+}
+
+log_success() {
+    echo -e "    ${GREEN}✓${NC} $1"
+}
+
+# Configuration
+KEYCHAIN_NAME="build.keychain"
+KEYCHAIN_PATH="$HOME/Library/Keychains/${KEYCHAIN_NAME}-db"
+
+# Environment variables required:
+# APPLE_CERTIFICATE_BASE64 - Base64-encoded .p12 certificate
+# APPLE_CERTIFICATE_PASSWORD - Password for the .p12 file
+# KEYCHAIN_PASSWORD - Password for the temporary keychain
+
+print_usage() {
+    echo "Usage: $0 [options]"
+    echo ""
+    echo "Options:"
+    echo "  --setup         Create keychain and import certificates"
+    echo "  --cleanup       Remove temporary keychain"
+    echo "  -h, --help      Show this help message"
+    echo ""
+    echo "Environment Variables Required:"
+    echo "  APPLE_CERTIFICATE_BASE64    Base64-encoded .p12 certificate"
+    echo "  APPLE_CERTIFICATE_PASSWORD  Password for the .p12 file"
+    echo "  KEYCHAIN_PASSWORD           Password for the temporary keychain"
+    echo ""
+    echo "Examples:"
+    echo "  $0 --setup      # Setup keychain for signing"
+    echo "  $0 --cleanup    # Remove temporary keychain after build"
+}
+
+# Parse arguments
+ACTION=""
+
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --setup)
+            ACTION="setup"
+            shift
+            ;;
+        --cleanup)
+            ACTION="cleanup"
+            shift
+            ;;
+        -h|--help)
+            print_usage
+            exit 0
+            ;;
+        *)
+            echo -e "${RED}Unknown option: $1${NC}"
+            print_usage
+            exit 1
+            ;;
+    esac
+done
+
+if [ -z "$ACTION" ]; then
+    echo -e "${RED}Error: No action specified${NC}"
+    print_usage
+    exit 1
+fi
+
+# Setup keychain and import certificates
+setup_keychain() {
+    log_step "Setting up code signing keychain..."
+
+    # Validate required environment variables
+    if [ -z "$APPLE_CERTIFICATE_BASE64" ]; then
+        log_error "APPLE_CERTIFICATE_BASE64 not set"
+        exit 1
+    fi
+
+    if [ -z "$APPLE_CERTIFICATE_PASSWORD" ]; then
+        log_error "APPLE_CERTIFICATE_PASSWORD not set"
+        exit 1
+    fi
+
+    if [ -z "$KEYCHAIN_PASSWORD" ]; then
+        log_error "KEYCHAIN_PASSWORD not set"
+        exit 1
+    fi
+
+    # Create temporary file for certificate
+    local cert_path="/tmp/certificate.p12"
+    echo "$APPLE_CERTIFICATE_BASE64" | base64 --decode > "$cert_path"
+    log_success "Decoded certificate to temporary file"
+
+    # Delete existing keychain if present
+    if [ -f "$KEYCHAIN_PATH" ]; then
+        security delete-keychain "$KEYCHAIN_PATH" 2>/dev/null || true
+        log_info "Removed existing build keychain"
+    fi
+
+    # Create new keychain
+    security create-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+    log_success "Created build keychain"
+
+    # Set keychain settings
+    # - Prevent keychain from auto-locking
+    # - Set to default keychain
+    security set-keychain-settings -lut 21600 "$KEYCHAIN_PATH"
+    security default-keychain -s "$KEYCHAIN_PATH"
+    log_success "Configured keychain settings"
+
+    # Unlock keychain
+    security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+    log_success "Unlocked keychain"
+
+    # Import certificate
+    security import "$cert_path" \
+        -k "$KEYCHAIN_PATH" \
+        -P "$APPLE_CERTIFICATE_PASSWORD" \
+        -T /usr/bin/codesign \
+        -T /usr/bin/productsign
+    log_success "Imported certificate"
+
+    # Set partition list (allows codesign to access without prompt)
+    security set-key-partition-list -S apple-tool:,apple:,codesign: \
+        -s -k "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+    log_success "Set key partition list"
+
+    # Add to search list
+    security list-keychains -d user -s "$KEYCHAIN_PATH" $(security list-keychains -d user | tr -d '"')
+    log_success "Added to keychain search list"
+
+    # Clean up temporary certificate file
+    rm -f "$cert_path"
+    log_info "Cleaned up temporary certificate file"
+
+    # Verify certificate was imported
+    log_info "Verifying certificate import..."
+    local cert_count
+    cert_count=$(security find-identity -v -p codesigning "$KEYCHAIN_PATH" | grep -c "valid identities found" || echo "0")
+
+    if security find-identity -v -p codesigning "$KEYCHAIN_PATH" | grep -q "Developer ID"; then
+        log_success "Developer ID certificate found in keychain"
+    else
+        log_warning "No Developer ID certificate found"
+        security find-identity -v -p codesigning "$KEYCHAIN_PATH"
+    fi
+
+    echo ""
+    log_success "Keychain setup complete"
+    log_info "Ready for code signing"
+}
+
+# Cleanup keychain
+cleanup_keychain() {
+    log_step "Cleaning up code signing keychain..."
+
+    if [ -f "$KEYCHAIN_PATH" ]; then
+        security delete-keychain "$KEYCHAIN_PATH"
+        log_success "Removed build keychain"
+    else
+        log_info "Build keychain not found (already cleaned up)"
+    fi
+
+    # Reset to login keychain
+    security default-keychain -s login.keychain-db 2>/dev/null || true
+    log_info "Reset default keychain"
+}
+
+# Execute action
+case $ACTION in
+    setup)
+        setup_keychain
+        ;;
+    cleanup)
+        cleanup_keychain
+        ;;
+esac

--- a/Scripts/sign_and_notarize.sh
+++ b/Scripts/sign_and_notarize.sh
@@ -1,0 +1,586 @@
+#!/bin/bash
+# ABOUTME: Code signing and notarization script for macOS distribution.
+# ABOUTME: Signs app bundle with Developer ID and submits for Apple notarization.
+
+set -e
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m' # No Color
+
+# Script location
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+# Build configuration
+BUILD_DIR="${PROJECT_ROOT}/Builds"
+MACOS_BUILD_DIR="${BUILD_DIR}/macOS"
+APP_NAME="OpenRange"
+APP_BUNDLE="${MACOS_BUILD_DIR}/${APP_NAME}.app"
+ENTITLEMENTS="${SCRIPT_DIR}/entitlements.plist"
+
+# Distribution
+DIST_DIR="${BUILD_DIR}/dist"
+
+# Environment variables (should be set externally or via --env-file)
+# APPLE_TEAM_ID - Your Apple Developer Team ID (e.g., ABCD1234EF)
+# APPLE_DEVELOPER_ID - Certificate name (e.g., "Developer ID Application: Your Name (TEAMID)")
+# APPLE_ID - Your Apple ID email for notarization
+# APPLE_APP_PASSWORD - App-specific password from appleid.apple.com
+
+# Parse command line arguments
+SIGN_ONLY=false
+NOTARIZE_ONLY=false
+CREATE_DMG=false
+VERBOSE=false
+DRY_RUN=false
+
+print_usage() {
+    echo "Usage: $0 [options]"
+    echo ""
+    echo "Options:"
+    echo "  --sign          Sign the app bundle only"
+    echo "  --notarize      Notarize only (assumes already signed)"
+    echo "  --dmg           Create DMG after signing/notarizing"
+    echo "  --all           Full pipeline: sign, notarize, create DMG"
+    echo "  --dry-run       Show what would be done without executing"
+    echo "  --verbose       Show detailed output"
+    echo "  -h, --help      Show this help message"
+    echo ""
+    echo "Environment Variables Required:"
+    echo "  APPLE_TEAM_ID        Apple Developer Team ID"
+    echo "  APPLE_DEVELOPER_ID   Developer ID Application certificate name"
+    echo "  APPLE_ID             Apple ID email for notarization"
+    echo "  APPLE_APP_PASSWORD   App-specific password for notarization"
+    echo ""
+    echo "Examples:"
+    echo "  $0 --sign              # Sign app bundle"
+    echo "  $0 --notarize          # Submit for notarization"
+    echo "  $0 --all               # Full release pipeline"
+    echo "  $0 --sign --dmg        # Sign and create DMG (skip notarization)"
+}
+
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --sign)
+            SIGN_ONLY=true
+            shift
+            ;;
+        --notarize)
+            NOTARIZE_ONLY=true
+            shift
+            ;;
+        --dmg)
+            CREATE_DMG=true
+            shift
+            ;;
+        --all)
+            SIGN_ONLY=false
+            NOTARIZE_ONLY=false
+            CREATE_DMG=true
+            shift
+            ;;
+        --dry-run)
+            DRY_RUN=true
+            shift
+            ;;
+        --verbose)
+            VERBOSE=true
+            shift
+            ;;
+        -h|--help)
+            print_usage
+            exit 0
+            ;;
+        *)
+            echo -e "${RED}Unknown option: $1${NC}"
+            print_usage
+            exit 1
+            ;;
+    esac
+done
+
+# Logging helpers
+log_step() {
+    echo ""
+    echo -e "${BLUE}==>${NC} ${GREEN}$1${NC}"
+}
+
+log_info() {
+    echo -e "    $1"
+}
+
+log_warning() {
+    echo -e "    ${YELLOW}Warning:${NC} $1"
+}
+
+log_error() {
+    echo -e "    ${RED}Error:${NC} $1"
+}
+
+log_success() {
+    echo -e "    ${GREEN}✓${NC} $1"
+}
+
+# Run command (respects dry-run mode)
+run_cmd() {
+    if [ "$DRY_RUN" = true ]; then
+        echo "    [DRY-RUN] $*"
+    else
+        if [ "$VERBOSE" = true ]; then
+            "$@"
+        else
+            "$@" > /dev/null 2>&1
+        fi
+    fi
+}
+
+# Validate environment
+validate_environment() {
+    log_step "Validating environment..."
+
+    local has_errors=false
+
+    # Check app bundle exists
+    if [ ! -d "$APP_BUNDLE" ]; then
+        log_error "App bundle not found at $APP_BUNDLE"
+        log_info "Run 'make build-app' first to create the app bundle"
+        has_errors=true
+    else
+        log_success "App bundle found"
+    fi
+
+    # Check entitlements file
+    if [ ! -f "$ENTITLEMENTS" ]; then
+        log_error "Entitlements file not found at $ENTITLEMENTS"
+        has_errors=true
+    else
+        log_success "Entitlements file found"
+    fi
+
+    # Check codesign
+    if ! command -v codesign &> /dev/null; then
+        log_error "codesign not found. Install Xcode command line tools."
+        has_errors=true
+    else
+        log_success "codesign available"
+    fi
+
+    # Check notarytool (for notarization)
+    if [ "$NOTARIZE_ONLY" = true ] || [ "$SIGN_ONLY" = false ]; then
+        if ! command -v xcrun &> /dev/null; then
+            log_error "xcrun not found. Install Xcode command line tools."
+            has_errors=true
+        else
+            log_success "xcrun available"
+        fi
+    fi
+
+    # Check required environment variables for signing
+    if [ "$NOTARIZE_ONLY" = false ]; then
+        if [ -z "$APPLE_DEVELOPER_ID" ]; then
+            log_error "APPLE_DEVELOPER_ID not set"
+            log_info "Set to your certificate name, e.g., 'Developer ID Application: Your Name (TEAMID)'"
+            has_errors=true
+        else
+            log_success "APPLE_DEVELOPER_ID set"
+
+            # Verify certificate exists in keychain
+            if [ "$DRY_RUN" = false ]; then
+                if ! security find-identity -v -p codesigning | grep -q "$APPLE_DEVELOPER_ID"; then
+                    log_warning "Certificate '$APPLE_DEVELOPER_ID' not found in keychain"
+                    log_info "Available signing identities:"
+                    security find-identity -v -p codesigning | head -5
+                fi
+            fi
+        fi
+    fi
+
+    # Check required environment variables for notarization
+    if [ "$SIGN_ONLY" = false ]; then
+        if [ -z "$APPLE_ID" ]; then
+            log_error "APPLE_ID not set (your Apple ID email)"
+            has_errors=true
+        else
+            log_success "APPLE_ID set"
+        fi
+
+        if [ -z "$APPLE_TEAM_ID" ]; then
+            log_error "APPLE_TEAM_ID not set"
+            has_errors=true
+        else
+            log_success "APPLE_TEAM_ID set"
+        fi
+
+        if [ -z "$APPLE_APP_PASSWORD" ]; then
+            log_error "APPLE_APP_PASSWORD not set"
+            log_info "Create at: https://appleid.apple.com/account/manage > App-Specific Passwords"
+            has_errors=true
+        else
+            log_success "APPLE_APP_PASSWORD set"
+        fi
+    fi
+
+    if [ "$has_errors" = true ]; then
+        echo ""
+        log_error "Environment validation failed. Please fix the issues above."
+        exit 1
+    fi
+}
+
+# Sign a single binary or bundle
+sign_binary() {
+    local binary_path="$1"
+    local binary_name="$(basename "$binary_path")"
+
+    log_info "Signing $binary_name..."
+
+    if [ "$DRY_RUN" = true ]; then
+        echo "    [DRY-RUN] codesign --force --options runtime --entitlements $ENTITLEMENTS --sign \"$APPLE_DEVELOPER_ID\" \"$binary_path\""
+        return
+    fi
+
+    codesign \
+        --force \
+        --options runtime \
+        --entitlements "$ENTITLEMENTS" \
+        --sign "$APPLE_DEVELOPER_ID" \
+        --timestamp \
+        "$binary_path"
+
+    # Verify signature
+    if codesign --verify --strict "$binary_path" 2>/dev/null; then
+        log_success "$binary_name signed successfully"
+    else
+        log_error "Failed to sign $binary_name"
+        exit 1
+    fi
+}
+
+# Sign the app bundle
+sign_app() {
+    log_step "Signing app bundle..."
+
+    # Sign libusb first (innermost)
+    local libusb_path=""
+    if [ -f "${APP_BUNDLE}/Contents/PlugIns/libusb-1.0.dylib" ]; then
+        libusb_path="${APP_BUNDLE}/Contents/PlugIns/libusb-1.0.dylib"
+    elif [ -f "${APP_BUNDLE}/Contents/Plugins/libusb-1.0.dylib" ]; then
+        libusb_path="${APP_BUNDLE}/Contents/Plugins/libusb-1.0.dylib"
+    fi
+
+    if [ -n "$libusb_path" ]; then
+        sign_binary "$libusb_path"
+    else
+        log_warning "libusb not found in app bundle"
+    fi
+
+    # Sign plugin bundle
+    local plugin_path=""
+    if [ -d "${APP_BUNDLE}/Contents/PlugIns/GC2MacPlugin.bundle" ]; then
+        plugin_path="${APP_BUNDLE}/Contents/PlugIns/GC2MacPlugin.bundle"
+    elif [ -d "${APP_BUNDLE}/Contents/Plugins/GC2MacPlugin.bundle" ]; then
+        plugin_path="${APP_BUNDLE}/Contents/Plugins/GC2MacPlugin.bundle"
+    fi
+
+    if [ -n "$plugin_path" ]; then
+        sign_binary "$plugin_path"
+    else
+        log_warning "GC2MacPlugin.bundle not found in app bundle"
+    fi
+
+    # Sign main app bundle (outermost, with deep)
+    log_info "Signing main app bundle (deep)..."
+
+    if [ "$DRY_RUN" = true ]; then
+        echo "    [DRY-RUN] codesign --deep --force --options runtime --entitlements $ENTITLEMENTS --sign \"$APPLE_DEVELOPER_ID\" \"$APP_BUNDLE\""
+    else
+        codesign \
+            --deep \
+            --force \
+            --options runtime \
+            --entitlements "$ENTITLEMENTS" \
+            --sign "$APPLE_DEVELOPER_ID" \
+            --timestamp \
+            "$APP_BUNDLE"
+    fi
+
+    # Verify the complete app
+    log_info "Verifying app bundle signature..."
+
+    if [ "$DRY_RUN" = true ]; then
+        echo "    [DRY-RUN] codesign --verify --deep --strict \"$APP_BUNDLE\""
+    else
+        if codesign --verify --deep --strict "$APP_BUNDLE"; then
+            log_success "App bundle signed and verified"
+        else
+            log_error "App bundle verification failed"
+            exit 1
+        fi
+
+        # Show signature info
+        if [ "$VERBOSE" = true ]; then
+            echo ""
+            log_info "Signature details:"
+            codesign -dv --verbose=4 "$APP_BUNDLE" 2>&1 | head -20
+        fi
+    fi
+}
+
+# Submit for notarization
+notarize_app() {
+    log_step "Submitting for notarization..."
+
+    mkdir -p "$DIST_DIR"
+    local zip_path="${DIST_DIR}/${APP_NAME}-notarization.zip"
+
+    # Create ZIP for notarization
+    log_info "Creating ZIP for notarization..."
+
+    if [ "$DRY_RUN" = true ]; then
+        echo "    [DRY-RUN] ditto -c -k --keepParent \"$APP_BUNDLE\" \"$zip_path\""
+    else
+        rm -f "$zip_path"
+        ditto -c -k --keepParent "$APP_BUNDLE" "$zip_path"
+        log_success "Created $zip_path ($(du -h "$zip_path" | cut -f1))"
+    fi
+
+    # Submit to Apple
+    log_info "Submitting to Apple notary service..."
+    log_info "(This may take several minutes)"
+
+    if [ "$DRY_RUN" = true ]; then
+        echo "    [DRY-RUN] xcrun notarytool submit \"$zip_path\" --apple-id \"$APPLE_ID\" --team-id \"$APPLE_TEAM_ID\" --password \"***\" --wait"
+    else
+        local submit_output
+        submit_output=$(xcrun notarytool submit "$zip_path" \
+            --apple-id "$APPLE_ID" \
+            --team-id "$APPLE_TEAM_ID" \
+            --password "$APPLE_APP_PASSWORD" \
+            --wait 2>&1)
+
+        echo "$submit_output"
+
+        # Check if successful
+        if echo "$submit_output" | grep -q "status: Accepted"; then
+            log_success "Notarization accepted!"
+
+            # Extract submission ID for logs
+            local submission_id
+            submission_id=$(echo "$submit_output" | grep -oE "id: [a-f0-9-]+" | head -1 | cut -d' ' -f2)
+
+            if [ -n "$submission_id" ]; then
+                log_info "Submission ID: $submission_id"
+
+                # Get detailed log
+                if [ "$VERBOSE" = true ]; then
+                    echo ""
+                    log_info "Notarization log:"
+                    xcrun notarytool log "$submission_id" \
+                        --apple-id "$APPLE_ID" \
+                        --team-id "$APPLE_TEAM_ID" \
+                        --password "$APPLE_APP_PASSWORD" 2>&1 | head -30
+                fi
+            fi
+        else
+            log_error "Notarization failed"
+
+            # Try to get error details
+            local submission_id
+            submission_id=$(echo "$submit_output" | grep -oE "id: [a-f0-9-]+" | head -1 | cut -d' ' -f2)
+
+            if [ -n "$submission_id" ]; then
+                echo ""
+                log_info "Fetching notarization log for details..."
+                xcrun notarytool log "$submission_id" \
+                    --apple-id "$APPLE_ID" \
+                    --team-id "$APPLE_TEAM_ID" \
+                    --password "$APPLE_APP_PASSWORD" 2>&1
+            fi
+
+            exit 1
+        fi
+    fi
+
+    # Staple ticket to app
+    log_info "Stapling notarization ticket to app..."
+
+    if [ "$DRY_RUN" = true ]; then
+        echo "    [DRY-RUN] xcrun stapler staple \"$APP_BUNDLE\""
+    else
+        if xcrun stapler staple "$APP_BUNDLE"; then
+            log_success "Notarization ticket stapled"
+        else
+            log_error "Failed to staple notarization ticket"
+            exit 1
+        fi
+    fi
+
+    # Clean up
+    if [ "$DRY_RUN" = false ]; then
+        rm -f "$zip_path"
+        log_info "Cleaned up temporary ZIP"
+    fi
+}
+
+# Get version from app bundle
+get_version() {
+    if [ -f "${APP_BUNDLE}/Contents/Info.plist" ]; then
+        /usr/libexec/PlistBuddy -c "Print CFBundleShortVersionString" "${APP_BUNDLE}/Contents/Info.plist" 2>/dev/null || echo "1.0.0"
+    else
+        echo "1.0.0"
+    fi
+}
+
+# Create DMG
+create_dmg() {
+    log_step "Creating DMG..."
+
+    mkdir -p "$DIST_DIR"
+
+    local version
+    version=$(get_version)
+    local dmg_name="${APP_NAME}-${version}.dmg"
+    local dmg_path="${DIST_DIR}/${dmg_name}"
+
+    # Remove existing DMG
+    rm -f "$dmg_path"
+
+    # Check for create-dmg (pretty DMG)
+    if command -v create-dmg &> /dev/null; then
+        log_info "Using create-dmg for styled DMG..."
+
+        if [ "$DRY_RUN" = true ]; then
+            echo "    [DRY-RUN] create-dmg ... \"$dmg_path\" \"$APP_BUNDLE\""
+        else
+            create-dmg \
+                --volname "$APP_NAME" \
+                --window-pos 200 120 \
+                --window-size 600 400 \
+                --icon-size 100 \
+                --icon "$APP_NAME.app" 175 120 \
+                --hide-extension "$APP_NAME.app" \
+                --app-drop-link 425 120 \
+                "$dmg_path" \
+                "$APP_BUNDLE" 2>&1 || true
+
+            # create-dmg returns non-zero even on success sometimes
+            if [ -f "$dmg_path" ]; then
+                log_success "Created styled DMG"
+            else
+                log_warning "create-dmg failed, falling back to hdiutil"
+                hdiutil create -volname "$APP_NAME" -srcfolder "$APP_BUNDLE" \
+                    -ov -format UDZO "$dmg_path"
+            fi
+        fi
+    else
+        log_info "Using hdiutil for simple DMG..."
+
+        if [ "$DRY_RUN" = true ]; then
+            echo "    [DRY-RUN] hdiutil create -volname \"$APP_NAME\" -srcfolder \"$APP_BUNDLE\" -ov -format UDZO \"$dmg_path\""
+        else
+            hdiutil create -volname "$APP_NAME" -srcfolder "$APP_BUNDLE" \
+                -ov -format UDZO "$dmg_path"
+        fi
+    fi
+
+    # Sign the DMG
+    if [ -n "$APPLE_DEVELOPER_ID" ]; then
+        log_info "Signing DMG..."
+
+        if [ "$DRY_RUN" = true ]; then
+            echo "    [DRY-RUN] codesign --sign \"$APPLE_DEVELOPER_ID\" \"$dmg_path\""
+        else
+            codesign --sign "$APPLE_DEVELOPER_ID" --timestamp "$dmg_path"
+            log_success "DMG signed"
+        fi
+
+        # Notarize DMG if we're doing full pipeline
+        if [ "$SIGN_ONLY" = false ] && [ -n "$APPLE_ID" ]; then
+            log_info "Notarizing DMG..."
+
+            if [ "$DRY_RUN" = true ]; then
+                echo "    [DRY-RUN] xcrun notarytool submit \"$dmg_path\" ... --wait"
+            else
+                local submit_output
+                submit_output=$(xcrun notarytool submit "$dmg_path" \
+                    --apple-id "$APPLE_ID" \
+                    --team-id "$APPLE_TEAM_ID" \
+                    --password "$APPLE_APP_PASSWORD" \
+                    --wait 2>&1)
+
+                if echo "$submit_output" | grep -q "status: Accepted"; then
+                    xcrun stapler staple "$dmg_path"
+                    log_success "DMG notarized and stapled"
+                else
+                    log_warning "DMG notarization failed (app is still notarized)"
+                fi
+            fi
+        fi
+    fi
+
+    if [ "$DRY_RUN" = false ] && [ -f "$dmg_path" ]; then
+        log_success "DMG created: $dmg_path ($(du -h "$dmg_path" | cut -f1))"
+    fi
+}
+
+# Main
+main() {
+    echo ""
+    echo -e "${GREEN}========================================${NC}"
+    echo -e "${GREEN}  GC2 Connect - Code Signing${NC}"
+    echo -e "${GREEN}========================================${NC}"
+    echo ""
+
+    if [ "$DRY_RUN" = true ]; then
+        log_warning "DRY-RUN MODE - No changes will be made"
+    fi
+
+    # Validate environment
+    validate_environment
+
+    # Execute requested operations
+    if [ "$NOTARIZE_ONLY" = true ]; then
+        notarize_app
+    elif [ "$SIGN_ONLY" = true ]; then
+        sign_app
+        if [ "$CREATE_DMG" = true ]; then
+            create_dmg
+        fi
+    else
+        # Full pipeline
+        sign_app
+        notarize_app
+        if [ "$CREATE_DMG" = true ]; then
+            create_dmg
+        fi
+    fi
+
+    # Summary
+    echo ""
+    echo -e "${GREEN}========================================${NC}"
+    echo -e "${GREEN}  Complete!${NC}"
+    echo -e "${GREEN}========================================${NC}"
+    echo ""
+
+    log_info "App bundle: $APP_BUNDLE"
+
+    if [ "$CREATE_DMG" = true ]; then
+        local version
+        version=$(get_version)
+        log_info "DMG: ${DIST_DIR}/${APP_NAME}-${version}.dmg"
+    fi
+
+    echo ""
+    log_info "Next steps:"
+    echo "    1. Test the app on a fresh Mac"
+    echo "    2. Verify no Gatekeeper warnings appear"
+    echo "    3. Upload to distribution channel"
+    echo ""
+}
+
+# Run main
+main "$@"

--- a/todo.md
+++ b/todo.md
@@ -3,13 +3,13 @@
 ## Current Status
 **Phase**: 8 - macOS Build & Release
 **Last Updated**: 2026-01-03
-**Next Prompt**: 36 (macOS Build Script and Configuration)
+**Next Prompt**: 23 (Android Plugin Project) or 29 (Integration Testing)
 **Prompts 43-46**: ✅ UI Refinement complete (Phase 7.5 done)
 **Physics**: ✅ Carry validated (PR #3) | ✅ Bounce improved (PR #33) | ✅ Roll improved (PR #35) | ✅ Validation (PR #37)
 **Protocol**: ✅ 0H shot parsing | ✅ 0M device status (PR #39)
 **GSPro**: ✅ Client complete (PR #43) | ✅ Buffer management (PR #53)
 **UI**: ✅ Prompts 43-46 complete (PR #55-59)
-**Build**: 🔄 Prompts 36-41 added for macOS/iOS/Android builds and CI/CD release workflow
+**Build**: ✅ Prompt 36 complete (PR #61) | 🔄 Prompts 37-41 pending for signing/notarization and CI/CD
 
 ---
 
@@ -141,46 +141,48 @@
 
 ### Phase 8: macOS Build & Release
 
-- [ ] **Prompt 36**: macOS Build Script and Configuration
-  - [ ] Update Makefile with comprehensive macOS targets
-    - [ ] `make build-macos` - Full macOS build with native plugin
-    - [ ] `make build-macos-dev` - Development build with debugging
-    - [ ] `make package-macos` - Create DMG installer
-    - [ ] `make clean-builds` - Clean all build artifacts
-  - [ ] Create build configuration script (`Scripts/build_macos.sh`)
-    - [ ] Build native plugin first (call `build_mac_plugin.sh`)
-    - [ ] Unity CLI build with correct parameters
-    - [ ] Post-build validation (bundle structure, library linking)
-    - [ ] Architecture verification (arm64/x86_64/universal)
-  - [ ] Update Unity Player Settings for production
-    - [ ] Bundle identifier: `com.openrange.gc2connect`
-    - [ ] Version numbering scheme (semver)
-    - [ ] IL2CPP scripting backend
-    - [ ] Architecture: Apple Silicon + Intel
-  - [ ] Create DMG packaging script
-    - [ ] Application folder symlink
-    - [ ] Background image and icon placement
-    - [ ] Compressed DMG output
-  - [ ] Add build verification tests
-  - [ ] Update CLAUDE.md with build instructions
+- [x] **Prompt 36**: macOS Build Script and Configuration ✅ (PR #61)
+  - [x] Created Scripts/build_macos.sh with comprehensive build orchestration
+    - [x] Pre-build validation (Unity, Xcode, libusb)
+    - [x] Native plugin build (calls build_mac_plugin.sh)
+    - [x] Unity CLI build with IL2CPP
+    - [x] Post-build verification (bundle structure, library paths)
+    - [x] Options: --skip-tests, --skip-plugin, --development, --version=X.Y.Z, --verbose
+  - [x] Updated Makefile with new targets
+    - [x] `make build-plugin` - Native plugin only
+    - [x] `make build-app` - Full build with tests
+    - [x] `make build-app-dev` - Development build (skip tests)
+    - [x] `make build-release` - Release with git tag version
+    - [x] `make package` - Create DMG for distribution
+    - [x] `make clean-builds` - Clean build outputs only
+  - [x] Created docs/BUILD_MACOS.md with comprehensive documentation
+    - [x] Prerequisites and installation
+    - [x] Quick start commands
+    - [x] Build options reference
+    - [x] Troubleshooting guide
+    - [x] Native plugin architecture notes
+  - [x] Updated CLAUDE.md with build instructions
 
-- [ ] **Prompt 37**: macOS Code Signing and Notarization
-  - [ ] Document Apple Developer requirements
-    - [ ] Developer ID Application certificate
-    - [ ] Developer ID Installer certificate
-    - [ ] App-specific password for notarization
-  - [ ] Create signing script (`Scripts/sign_macos.sh`)
-    - [ ] Sign native plugin (GC2MacPlugin.bundle)
-    - [ ] Sign libusb dylib
-    - [ ] Sign main application bundle
-    - [ ] Deep signing with entitlements
-  - [ ] Create notarization script (`Scripts/notarize_macos.sh`)
-    - [ ] Upload to Apple notary service
-    - [ ] Wait for notarization result
-    - [ ] Staple ticket to app
-  - [ ] Create entitlements file for USB access
-  - [ ] Add GitHub secrets documentation
-  - [ ] Update Makefile with signing targets
+- [x] **Prompt 37**: macOS Code Signing and Notarization ✅ (PR #63)
+  - [x] Created Scripts/entitlements.plist with required entitlements
+    - [x] IL2CPP JIT and memory entitlements
+    - [x] USB device access entitlement
+    - [x] Library validation bypass for libusb
+  - [x] Created Scripts/sign_and_notarize.sh with full workflow
+    - [x] Sign libusb.dylib, GC2MacPlugin.bundle, OpenRange.app
+    - [x] Deep signing with hardened runtime
+    - [x] Notarization submission and stapling
+    - [x] DMG creation and signing
+    - [x] Dry-run mode for testing
+  - [x] Created Scripts/setup_signing.sh for CI
+    - [x] Import certificates from base64 env vars
+    - [x] Create temporary keychain
+    - [x] Cleanup target for post-build
+  - [x] Updated Makefile with signing targets
+    - [x] sign, notarize, dmg, release-macos
+    - [x] setup-signing, cleanup-signing
+  - [x] Updated docs/BUILD_MACOS.md with comprehensive signing docs
+  - [x] Updated CLAUDE.md with signing commands
 
 ---
 
@@ -363,6 +365,8 @@ All validated ✅ (PR #3):
 ---
 
 ## Recent Issue Log (Last 5 Entries)
+
+**2026-01-03 (macOS Build Script)**: Prompt 36 complete (PR #61). Created Scripts/build_macos.sh with comprehensive build orchestration (validation, plugin, tests, Unity build, verification). Updated Makefile with build-plugin, build-app, build-app-dev, build-release, package, clean-builds targets. Created docs/BUILD_MACOS.md with full documentation. Updated CLAUDE.md with build instructions.
 
 **2026-01-03 (Settings Panel Dropdown Fixes)**: Prompt 45 complete (PR #58). Fixed dropdown issues - ScrollRect wiring (viewport/content missing), z-order (Canvas.sortingOrder=100), item height (44px), checkmark (Unity's built-in Checkmark.psd instead of Unicode). Fixed Settings button moved to left side. Critical fix: EditorUtility.DisplayDialog() returns false in batchmode - added Application.isBatchMode check to SceneGenerator.GenerateAllScenes(). 13 new layout tests.
 


### PR DESCRIPTION
## Summary

Implements Prompt 37 from plan.md - macOS Code Signing and Notarization infrastructure for distributing the app outside the Mac App Store.

### New Files

- **Scripts/entitlements.plist**: App entitlements for IL2CPP runtime, USB access, and libusb loading
- **Scripts/sign_and_notarize.sh**: Main signing and notarization script (~350 lines)
  - Sign libusb, native plugin, and app bundle with hardened runtime
  - Notarization via xcrun notarytool with status polling
  - Signed DMG creation with create-dmg or hdiutil fallback
  - Dry-run mode for testing
- **Scripts/setup_signing.sh**: CI keychain management (~150 lines)
  - Import certificates from base64 environment variables
  - Create isolated build keychain for CI

### Makefile Targets

| Target | Description |
|--------|-------------|
| `make sign` | Sign app bundle only |
| `make notarize` | Submit for notarization and staple |
| `make dmg` | Create signed DMG |
| `make release-macos` | Full pipeline (build + sign + notarize + DMG) |
| `make setup-signing` | Import certificates for CI |
| `make cleanup-signing` | Remove CI keychain |

### Environment Variables

| Variable | Purpose |
|----------|---------|
| `APPLE_DEVELOPER_ID` | Certificate name for signing |
| `APPLE_ID` | Apple ID for notarization |
| `APPLE_TEAM_ID` | Team ID for notarization |
| `APPLE_APP_PASSWORD` | App-specific password |
| `APPLE_CERTIFICATE_BASE64` | Base64-encoded .p12 (CI only) |
| `APPLE_CERTIFICATE_PASSWORD` | Certificate password (CI only) |
| `KEYCHAIN_PASSWORD` | Temp keychain password (CI only) |

## Test plan
- [x] All 1722 EditMode tests pass
- [ ] Dry-run mode works: `./Scripts/sign_and_notarize.sh --all --dry-run`
- [ ] Manual signing works with real credentials (requires Apple Developer account)
- [ ] CI keychain setup/cleanup works in GitHub Actions

Closes #62