### PR TITLE
feat(ui): Add Bridge Mode UI components

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 [Bb]uilds/
 [Ll]ogs/
 [Uu]ser[Ss]ettings/
+.utmp/
 
 # Visual Studio cache directory
 .vs/

--- a/Assets/Editor/BridgeModeUIGenerator.cs
+++ b/Assets/Editor/BridgeModeUIGenerator.cs
@@ -1,0 +1,523 @@
+// ABOUTME: Editor tool for creating Bridge Mode UI prefabs.
+// ABOUTME: Creates BridgeModeOverlay (floating status) and BridgeModeToggle (settings panel) prefabs.
+
+using UnityEngine;
+using UnityEditor;
+using UnityEngine.UI;
+using TMPro;
+using OpenRange.UI;
+
+namespace OpenRange.Editor
+{
+    /// <summary>
+    /// Editor tool for creating Bridge Mode UI prefabs.
+    /// </summary>
+    public static class BridgeModeUIGenerator
+    {
+        private const string PrefabPath = "Assets/Prefabs/UI";
+
+        #region Menu Items
+
+        [MenuItem("OpenRange/Create Bridge Mode Overlay Prefab")]
+        public static void CreateBridgeModeOverlayPrefab()
+        {
+            EnsureDirectories();
+
+            var overlayGO = CreateBridgeModeOverlay();
+
+            string path = $"{PrefabPath}/BridgeModeOverlay.prefab";
+            PrefabUtility.SaveAsPrefabAsset(overlayGO, path);
+            Object.DestroyImmediate(overlayGO);
+
+            AssetDatabase.Refresh();
+            Debug.Log($"BridgeModeUIGenerator: Created BridgeModeOverlay.prefab at {path}");
+        }
+
+        [MenuItem("OpenRange/Create Bridge Mode Toggle Prefab")]
+        public static void CreateBridgeModeTogglePrefab()
+        {
+            EnsureDirectories();
+
+            var toggleGO = CreateBridgeModeToggle();
+
+            string path = $"{PrefabPath}/BridgeModeToggle.prefab";
+            PrefabUtility.SaveAsPrefabAsset(toggleGO, path);
+            Object.DestroyImmediate(toggleGO);
+
+            AssetDatabase.Refresh();
+            Debug.Log($"BridgeModeUIGenerator: Created BridgeModeToggle.prefab at {path}");
+        }
+
+        [MenuItem("OpenRange/Create All Bridge Mode UI Prefabs")]
+        public static void CreateAllPrefabs()
+        {
+            CreateBridgeModeOverlayPrefab();
+            CreateBridgeModeTogglePrefab();
+            Debug.Log("BridgeModeUIGenerator: Created all Bridge Mode UI prefabs");
+        }
+
+        #endregion
+
+        #region Private Methods
+
+        private static void EnsureDirectories()
+        {
+            if (!AssetDatabase.IsValidFolder("Assets/Prefabs"))
+            {
+                AssetDatabase.CreateFolder("Assets", "Prefabs");
+            }
+            if (!AssetDatabase.IsValidFolder(PrefabPath))
+            {
+                AssetDatabase.CreateFolder("Assets/Prefabs", "UI");
+            }
+        }
+
+        private static GameObject CreateBridgeModeOverlay()
+        {
+            var overlayGO = new GameObject("BridgeModeOverlay");
+
+            // RectTransform - floating, bottom-right corner by default
+            var rectTransform = overlayGO.AddComponent<RectTransform>();
+            rectTransform.anchorMin = new Vector2(1f, 0f);
+            rectTransform.anchorMax = new Vector2(1f, 0f);
+            rectTransform.pivot = new Vector2(1f, 0f);
+            rectTransform.anchoredPosition = new Vector2(-20f, 20f);
+            rectTransform.sizeDelta = new Vector2(180f, 70f);
+
+            // Background panel
+            var bgImage = overlayGO.AddComponent<Image>();
+            bgImage.color = new Color(0.1f, 0.1f, 0.1f, 0.85f);
+
+            // CanvasGroup for animations and visibility
+            var canvasGroup = overlayGO.AddComponent<CanvasGroup>();
+            canvasGroup.alpha = 0f; // Start hidden
+
+            // Main vertical layout
+            var mainLayout = overlayGO.AddComponent<VerticalLayoutGroup>();
+            mainLayout.spacing = 4f;
+            mainLayout.padding = new RectOffset(10, 10, 8, 8);
+            mainLayout.childAlignment = TextAnchor.UpperLeft;
+            mainLayout.childControlWidth = true;
+            mainLayout.childControlHeight = true;
+            mainLayout.childForceExpandWidth = true;
+            mainLayout.childForceExpandHeight = false;
+
+            // --- Compact Header Row ---
+            var headerRowGO = new GameObject("HeaderRow");
+            headerRowGO.transform.SetParent(overlayGO.transform, false);
+            var headerRect = headerRowGO.AddComponent<RectTransform>();
+            var headerLayout = headerRowGO.AddComponent<LayoutElement>();
+            headerLayout.preferredHeight = 24f;
+
+            var headerHLayout = headerRowGO.AddComponent<HorizontalLayoutGroup>();
+            headerHLayout.spacing = 6f;
+            headerHLayout.childAlignment = TextAnchor.MiddleLeft;
+            headerHLayout.childControlWidth = false;
+            headerHLayout.childControlHeight = true;
+            headerHLayout.childForceExpandWidth = false;
+            headerHLayout.childForceExpandHeight = true;
+
+            // Status icon (LED indicator)
+            var iconGO = new GameObject("StatusIcon");
+            iconGO.transform.SetParent(headerRowGO.transform, false);
+            var iconRect = iconGO.AddComponent<RectTransform>();
+            iconRect.sizeDelta = new Vector2(12f, 12f);
+            var iconLayoutElem = iconGO.AddComponent<LayoutElement>();
+            iconLayoutElem.preferredWidth = 12f;
+            iconLayoutElem.preferredHeight = 12f;
+            iconLayoutElem.minWidth = 12f;
+            iconLayoutElem.minHeight = 12f;
+
+            var statusIcon = iconGO.AddComponent<Image>();
+            statusIcon.color = BridgeModeOverlay.DisconnectedColor;
+
+            // Status text
+            var statusTextGO = new GameObject("StatusText");
+            statusTextGO.transform.SetParent(headerRowGO.transform, false);
+            var statusTextLayout = statusTextGO.AddComponent<LayoutElement>();
+            statusTextLayout.flexibleWidth = 1f;
+            statusTextLayout.minWidth = 80f;
+
+            var statusText = statusTextGO.AddComponent<TextMeshProUGUI>();
+            statusText.text = "Disconnected";
+            statusText.alignment = TextAlignmentOptions.MidlineLeft;
+            statusText.color = UITheme.TextPrimary;
+            statusText.fontSize = 12f;
+            statusText.raycastTarget = false;
+
+            // --- Shots Relayed Row ---
+            var shotsRowGO = new GameObject("ShotsRow");
+            shotsRowGO.transform.SetParent(overlayGO.transform, false);
+            var shotsLayout = shotsRowGO.AddComponent<LayoutElement>();
+            shotsLayout.preferredHeight = 20f;
+
+            var shotsRelayedText = shotsRowGO.AddComponent<TextMeshProUGUI>();
+            shotsRelayedText.text = "0 shots";
+            shotsRelayedText.alignment = TextAlignmentOptions.MidlineLeft;
+            shotsRelayedText.color = UITheme.TextSecondary;
+            shotsRelayedText.fontSize = 11f;
+            shotsRelayedText.raycastTarget = false;
+
+            // --- Expanded Panel (hidden by default) ---
+            var expandedPanelGO = new GameObject("ExpandedPanel");
+            expandedPanelGO.transform.SetParent(overlayGO.transform, false);
+            var expandedRect = expandedPanelGO.AddComponent<RectTransform>();
+            var expandedLayout = expandedPanelGO.AddComponent<LayoutElement>();
+            expandedLayout.preferredHeight = 40f;
+            var expandedCanvasGroup = expandedPanelGO.AddComponent<CanvasGroup>();
+            expandedPanelGO.SetActive(false);
+
+            var expandedVLayout = expandedPanelGO.AddComponent<VerticalLayoutGroup>();
+            expandedVLayout.spacing = 4f;
+            expandedVLayout.childAlignment = TextAnchor.UpperLeft;
+            expandedVLayout.childControlWidth = true;
+            expandedVLayout.childControlHeight = true;
+            expandedVLayout.childForceExpandWidth = true;
+            expandedVLayout.childForceExpandHeight = false;
+
+            // Duration text
+            var durationGO = new GameObject("DurationText");
+            durationGO.transform.SetParent(expandedPanelGO.transform, false);
+            var durationLayout = durationGO.AddComponent<LayoutElement>();
+            durationLayout.preferredHeight = 16f;
+
+            var durationText = durationGO.AddComponent<TextMeshProUGUI>();
+            durationText.text = "0m 00s";
+            durationText.alignment = TextAlignmentOptions.MidlineLeft;
+            durationText.color = UITheme.TextSecondary;
+            durationText.fontSize = 10f;
+            durationText.raycastTarget = false;
+
+            // Disable button
+            var disableButtonGO = new GameObject("DisableButton");
+            disableButtonGO.transform.SetParent(expandedPanelGO.transform, false);
+            var disableButtonRect = disableButtonGO.AddComponent<RectTransform>();
+            disableButtonRect.sizeDelta = new Vector2(60f, 20f);
+            var disableButtonLayout = disableButtonGO.AddComponent<LayoutElement>();
+            disableButtonLayout.preferredWidth = 60f;
+            disableButtonLayout.preferredHeight = 20f;
+
+            var disableButtonImage = disableButtonGO.AddComponent<Image>();
+            disableButtonImage.color = new Color(0.5f, 0.2f, 0.2f, 1f);
+
+            var disableButton = disableButtonGO.AddComponent<Button>();
+            disableButton.targetGraphic = disableButtonImage;
+
+            var disableButtonTextGO = new GameObject("Text");
+            disableButtonTextGO.transform.SetParent(disableButtonGO.transform, false);
+            var disableButtonTextRect = disableButtonTextGO.AddComponent<RectTransform>();
+            disableButtonTextRect.anchorMin = Vector2.zero;
+            disableButtonTextRect.anchorMax = Vector2.one;
+            disableButtonTextRect.sizeDelta = Vector2.zero;
+
+            var disableButtonText = disableButtonTextGO.AddComponent<TextMeshProUGUI>();
+            disableButtonText.text = "Disable";
+            disableButtonText.alignment = TextAlignmentOptions.Center;
+            disableButtonText.color = Color.white;
+            disableButtonText.fontSize = 10f;
+            disableButtonText.raycastTarget = false;
+
+            // Add BridgeModeOverlay component and wire up references
+            var overlay = overlayGO.AddComponent<BridgeModeOverlay>();
+
+            var so = new SerializedObject(overlay);
+            so.FindProperty("_statusIcon").objectReferenceValue = statusIcon;
+            so.FindProperty("_statusText").objectReferenceValue = statusText;
+            so.FindProperty("_shotsRelayedText").objectReferenceValue = shotsRelayedText;
+            so.FindProperty("_expandedPanel").objectReferenceValue = expandedPanelGO;
+            so.FindProperty("_disableButton").objectReferenceValue = disableButton;
+            so.FindProperty("_durationText").objectReferenceValue = durationText;
+            so.FindProperty("_canvasGroup").objectReferenceValue = canvasGroup;
+            so.ApplyModifiedPropertiesWithoutUndo();
+
+            return overlayGO;
+        }
+
+        private static GameObject CreateBridgeModeToggle()
+        {
+            var toggleGO = new GameObject("BridgeModeToggle");
+
+            // RectTransform
+            var rectTransform = toggleGO.AddComponent<RectTransform>();
+            rectTransform.sizeDelta = new Vector2(300f, 200f);
+
+            // Main vertical layout
+            var mainLayout = toggleGO.AddComponent<VerticalLayoutGroup>();
+            mainLayout.spacing = 10f;
+            mainLayout.padding = new RectOffset(12, 12, 12, 12);
+            mainLayout.childAlignment = TextAnchor.UpperLeft;
+            mainLayout.childControlWidth = true;
+            mainLayout.childControlHeight = true;
+            mainLayout.childForceExpandWidth = true;
+            mainLayout.childForceExpandHeight = false;
+
+            // --- Header Row (Title + Toggle) ---
+            var headerRowGO = new GameObject("HeaderRow");
+            headerRowGO.transform.SetParent(toggleGO.transform, false);
+            var headerLayout = headerRowGO.AddComponent<LayoutElement>();
+            headerLayout.preferredHeight = 30f;
+
+            var headerHLayout = headerRowGO.AddComponent<HorizontalLayoutGroup>();
+            headerHLayout.spacing = 10f;
+            headerHLayout.childAlignment = TextAnchor.MiddleLeft;
+            headerHLayout.childControlWidth = false;
+            headerHLayout.childControlHeight = true;
+            headerHLayout.childForceExpandWidth = false;
+            headerHLayout.childForceExpandHeight = true;
+
+            // Title text
+            var titleGO = new GameObject("Title");
+            titleGO.transform.SetParent(headerRowGO.transform, false);
+            var titleLayout = titleGO.AddComponent<LayoutElement>();
+            titleLayout.flexibleWidth = 1f;
+            titleLayout.minWidth = 150f;
+
+            var titleText = titleGO.AddComponent<TextMeshProUGUI>();
+            titleText.text = "Bridge Mode";
+            titleText.alignment = TextAlignmentOptions.MidlineLeft;
+            titleText.color = UITheme.TextPrimary;
+            titleText.fontSize = 16f;
+            titleText.fontStyle = FontStyles.Bold;
+            titleText.raycastTarget = false;
+
+            // Enable toggle
+            var enableToggleGO = CreateToggle("EnableToggle");
+            enableToggleGO.transform.SetParent(headerRowGO.transform, false);
+            var enableToggle = enableToggleGO.GetComponent<Toggle>();
+
+            // --- Description ---
+            var descGO = new GameObject("Description");
+            descGO.transform.SetParent(toggleGO.transform, false);
+            var descLayout = descGO.AddComponent<LayoutElement>();
+            descLayout.preferredHeight = 32f;
+
+            var descText = descGO.AddComponent<TextMeshProUGUI>();
+            descText.text = "Relay GC2 shots to GSPro in background.\nFor use with Moonlight streaming.";
+            descText.alignment = TextAlignmentOptions.TopLeft;
+            descText.color = UITheme.TextSecondary;
+            descText.fontSize = 11f;
+            descText.raycastTarget = false;
+
+            // --- Battery Warning ---
+            var batteryWarningGO = new GameObject("BatteryWarning");
+            batteryWarningGO.transform.SetParent(toggleGO.transform, false);
+            var batteryLayout = batteryWarningGO.AddComponent<LayoutElement>();
+            batteryLayout.preferredHeight = 20f;
+
+            var batteryText = batteryWarningGO.AddComponent<TextMeshProUGUI>();
+            batteryText.text = "⚠ Uses more battery while active";
+            batteryText.alignment = TextAlignmentOptions.MidlineLeft;
+            batteryText.color = new Color(1f, 0.8f, 0.2f, 1f);
+            batteryText.fontSize = 10f;
+            batteryText.raycastTarget = false;
+            batteryWarningGO.SetActive(false);
+
+            // --- Config Panel (shown when enabled) ---
+            var configPanelGO = new GameObject("ConfigPanel");
+            configPanelGO.transform.SetParent(toggleGO.transform, false);
+            var configLayout = configPanelGO.AddComponent<LayoutElement>();
+            configLayout.preferredHeight = 100f;
+
+            var configCanvasGroup = configPanelGO.AddComponent<CanvasGroup>();
+            configCanvasGroup.alpha = 0f;
+            configCanvasGroup.interactable = false;
+            configCanvasGroup.blocksRaycasts = false;
+
+            var configVLayout = configPanelGO.AddComponent<VerticalLayoutGroup>();
+            configVLayout.spacing = 8f;
+            configVLayout.childAlignment = TextAnchor.UpperLeft;
+            configVLayout.childControlWidth = true;
+            configVLayout.childControlHeight = true;
+            configVLayout.childForceExpandWidth = true;
+            configVLayout.childForceExpandHeight = false;
+
+            // Host input row
+            var hostRowGO = CreateInputRow("HostRow", "GSPro Host:", "localhost", out var hostInput);
+            hostRowGO.transform.SetParent(configPanelGO.transform, false);
+
+            // Port input row
+            var portRowGO = CreateInputRow("PortRow", "Port:", "921", out var portInput);
+            portRowGO.transform.SetParent(configPanelGO.transform, false);
+
+            // Status row
+            var statusRowGO = new GameObject("StatusRow");
+            statusRowGO.transform.SetParent(configPanelGO.transform, false);
+            var statusRowLayout = statusRowGO.AddComponent<LayoutElement>();
+            statusRowLayout.preferredHeight = 20f;
+
+            var statusRowHLayout = statusRowGO.AddComponent<HorizontalLayoutGroup>();
+            statusRowHLayout.spacing = 8f;
+            statusRowHLayout.childAlignment = TextAnchor.MiddleLeft;
+            statusRowHLayout.childControlWidth = false;
+            statusRowHLayout.childControlHeight = true;
+            statusRowHLayout.childForceExpandWidth = false;
+            statusRowHLayout.childForceExpandHeight = true;
+
+            var statusLabelGO = new GameObject("Label");
+            statusLabelGO.transform.SetParent(statusRowGO.transform, false);
+            var statusLabelLayout = statusLabelGO.AddComponent<LayoutElement>();
+            statusLabelLayout.preferredWidth = 50f;
+            var statusLabel = statusLabelGO.AddComponent<TextMeshProUGUI>();
+            statusLabel.text = "Status:";
+            statusLabel.alignment = TextAlignmentOptions.MidlineLeft;
+            statusLabel.color = UITheme.TextSecondary;
+            statusLabel.fontSize = 11f;
+            statusLabel.raycastTarget = false;
+
+            var statusValueGO = new GameObject("StatusText");
+            statusValueGO.transform.SetParent(statusRowGO.transform, false);
+            var statusValueLayout = statusValueGO.AddComponent<LayoutElement>();
+            statusValueLayout.flexibleWidth = 1f;
+            var statusText = statusValueGO.AddComponent<TextMeshProUGUI>();
+            statusText.text = "Disconnected";
+            statusText.alignment = TextAlignmentOptions.MidlineLeft;
+            statusText.color = BridgeModeToggle.DisconnectedColor;
+            statusText.fontSize = 11f;
+            statusText.raycastTarget = false;
+
+            // Connect button
+            var connectButtonGO = new GameObject("ConnectButton");
+            connectButtonGO.transform.SetParent(configPanelGO.transform, false);
+            var connectButtonRect = connectButtonGO.AddComponent<RectTransform>();
+            var connectButtonLayout = connectButtonGO.AddComponent<LayoutElement>();
+            connectButtonLayout.preferredHeight = 28f;
+
+            var connectButtonImage = connectButtonGO.AddComponent<Image>();
+            connectButtonImage.color = UITheme.AccentGreen;
+
+            var connectButton = connectButtonGO.AddComponent<Button>();
+            connectButton.targetGraphic = connectButtonImage;
+
+            var connectButtonTextGO = new GameObject("Text");
+            connectButtonTextGO.transform.SetParent(connectButtonGO.transform, false);
+            var connectButtonTextRect = connectButtonTextGO.AddComponent<RectTransform>();
+            connectButtonTextRect.anchorMin = Vector2.zero;
+            connectButtonTextRect.anchorMax = Vector2.one;
+            connectButtonTextRect.sizeDelta = Vector2.zero;
+
+            var connectButtonText = connectButtonTextGO.AddComponent<TextMeshProUGUI>();
+            connectButtonText.text = "Connect";
+            connectButtonText.alignment = TextAlignmentOptions.Center;
+            connectButtonText.color = Color.white;
+            connectButtonText.fontSize = 13f;
+            connectButtonText.fontStyle = FontStyles.Bold;
+            connectButtonText.raycastTarget = false;
+
+            // Add BridgeModeToggle component and wire up references
+            var bridgeModeToggle = toggleGO.AddComponent<BridgeModeToggle>();
+
+            var so = new SerializedObject(bridgeModeToggle);
+            so.FindProperty("_enableToggle").objectReferenceValue = enableToggle;
+            so.FindProperty("_titleText").objectReferenceValue = titleText;
+            so.FindProperty("_descriptionText").objectReferenceValue = descText;
+            so.FindProperty("_configPanel").objectReferenceValue = configCanvasGroup;
+            so.FindProperty("_hostInput").objectReferenceValue = hostInput;
+            so.FindProperty("_portInput").objectReferenceValue = portInput;
+            so.FindProperty("_connectButton").objectReferenceValue = connectButton;
+            so.FindProperty("_connectButtonText").objectReferenceValue = connectButtonText;
+            so.FindProperty("_statusText").objectReferenceValue = statusText;
+            so.FindProperty("_batteryWarningText").objectReferenceValue = batteryText;
+            so.ApplyModifiedPropertiesWithoutUndo();
+
+            return toggleGO;
+        }
+
+        private static GameObject CreateToggle(string name)
+        {
+            var toggleGO = new GameObject(name);
+            var toggleRect = toggleGO.AddComponent<RectTransform>();
+            toggleRect.sizeDelta = new Vector2(50f, 26f);
+            var toggleLayout = toggleGO.AddComponent<LayoutElement>();
+            toggleLayout.preferredWidth = 50f;
+            toggleLayout.preferredHeight = 26f;
+
+            // Background
+            var bgImage = toggleGO.AddComponent<Image>();
+            bgImage.color = new Color(0.3f, 0.3f, 0.3f, 1f);
+
+            var toggle = toggleGO.AddComponent<Toggle>();
+            toggle.targetGraphic = bgImage;
+
+            // Checkmark
+            var checkGO = new GameObject("Checkmark");
+            checkGO.transform.SetParent(toggleGO.transform, false);
+            var checkRect = checkGO.AddComponent<RectTransform>();
+            checkRect.anchorMin = new Vector2(0.5f, 0f);
+            checkRect.anchorMax = new Vector2(1f, 1f);
+            checkRect.sizeDelta = Vector2.zero;
+
+            var checkImage = checkGO.AddComponent<Image>();
+            checkImage.color = UITheme.AccentGreen;
+
+            toggle.graphic = checkImage;
+            toggle.isOn = false;
+
+            return toggleGO;
+        }
+
+        private static GameObject CreateInputRow(string name, string label, string defaultValue, out TMP_InputField inputField)
+        {
+            var rowGO = new GameObject(name);
+            var rowLayout = rowGO.AddComponent<LayoutElement>();
+            rowLayout.preferredHeight = 24f;
+
+            var rowHLayout = rowGO.AddComponent<HorizontalLayoutGroup>();
+            rowHLayout.spacing = 8f;
+            rowHLayout.childAlignment = TextAnchor.MiddleLeft;
+            rowHLayout.childControlWidth = false;
+            rowHLayout.childControlHeight = true;
+            rowHLayout.childForceExpandWidth = false;
+            rowHLayout.childForceExpandHeight = true;
+
+            // Label
+            var labelGO = new GameObject("Label");
+            labelGO.transform.SetParent(rowGO.transform, false);
+            var labelLayout = labelGO.AddComponent<LayoutElement>();
+            labelLayout.preferredWidth = 70f;
+
+            var labelText = labelGO.AddComponent<TextMeshProUGUI>();
+            labelText.text = label;
+            labelText.alignment = TextAlignmentOptions.MidlineLeft;
+            labelText.color = UITheme.TextSecondary;
+            labelText.fontSize = 11f;
+            labelText.raycastTarget = false;
+
+            // Input field
+            var inputGO = new GameObject("Input");
+            inputGO.transform.SetParent(rowGO.transform, false);
+            var inputRect = inputGO.AddComponent<RectTransform>();
+            inputRect.sizeDelta = new Vector2(120f, 22f);
+            var inputLayout = inputGO.AddComponent<LayoutElement>();
+            inputLayout.preferredWidth = 120f;
+            inputLayout.preferredHeight = 22f;
+
+            var inputBg = inputGO.AddComponent<Image>();
+            inputBg.color = new Color(0.15f, 0.15f, 0.15f, 1f);
+
+            inputField = inputGO.AddComponent<TMP_InputField>();
+            inputField.text = defaultValue;
+
+            // Text area
+            var textAreaGO = new GameObject("Text Area");
+            textAreaGO.transform.SetParent(inputGO.transform, false);
+            var textAreaRect = textAreaGO.AddComponent<RectTransform>();
+            textAreaRect.anchorMin = Vector2.zero;
+            textAreaRect.anchorMax = Vector2.one;
+            textAreaRect.offsetMin = new Vector2(6f, 2f);
+            textAreaRect.offsetMax = new Vector2(-6f, -2f);
+
+            var inputText = textAreaGO.AddComponent<TextMeshProUGUI>();
+            inputText.text = defaultValue;
+            inputText.alignment = TextAlignmentOptions.MidlineLeft;
+            inputText.color = UITheme.TextPrimary;
+            inputText.fontSize = 11f;
+
+            inputField.textComponent = inputText;
+            inputField.textViewport = textAreaRect;
+
+            return rowGO;
+        }
+
+        #endregion
+    }
+}

--- a/Assets/Editor/BridgeModeUIGenerator.cs.meta
+++ b/Assets/Editor/BridgeModeUIGenerator.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 1b11fa8346c294828b88021a61d59613

--- a/Assets/Scripts/UI/BridgeModeOverlay.cs
+++ b/Assets/Scripts/UI/BridgeModeOverlay.cs
@@ -1,0 +1,543 @@
+// ABOUTME: Floating UI overlay shown when Bridge Mode is active in foreground.
+// ABOUTME: Displays GSPro connection status, shots relayed count, and expandable controls.
+
+using System;
+using System.Collections;
+using TMPro;
+using UnityEngine;
+using UnityEngine.EventSystems;
+using UnityEngine.UI;
+
+namespace OpenRange.UI
+{
+    /// <summary>
+    /// Connection status for Bridge Mode overlay.
+    /// </summary>
+    public enum BridgeConnectionStatus
+    {
+        /// <summary>Not connected to GSPro.</summary>
+        Disconnected,
+        /// <summary>Attempting to connect.</summary>
+        Connecting,
+        /// <summary>Successfully connected to GSPro.</summary>
+        Connected,
+        /// <summary>Connection error occurred.</summary>
+        Error
+    }
+
+    /// <summary>
+    /// Floating overlay shown when Bridge Mode is active.
+    /// Displays minimal status info and can be expanded for controls.
+    /// </summary>
+    public class BridgeModeOverlay : MonoBehaviour, IPointerClickHandler, IDragHandler, IBeginDragHandler, IEndDragHandler
+    {
+        #region Static Colors
+
+        /// <summary>Green color for connected state.</summary>
+        public static readonly Color ConnectedColor = new Color(0.2f, 0.9f, 0.2f, 1f);
+
+        /// <summary>Yellow color for connecting state.</summary>
+        public static readonly Color ConnectingColor = new Color(1f, 0.8f, 0.2f, 1f);
+
+        /// <summary>Gray color for disconnected state.</summary>
+        public static readonly Color DisconnectedColor = new Color(0.5f, 0.5f, 0.5f, 1f);
+
+        /// <summary>Red color for error state.</summary>
+        public static readonly Color ErrorColor = new Color(0.9f, 0.2f, 0.2f, 1f);
+
+        #endregion
+
+        #region Serialized Fields
+
+        [Header("Compact View")]
+        [SerializeField] private Image _statusIcon;
+        [SerializeField] private TextMeshProUGUI _statusText;
+        [SerializeField] private TextMeshProUGUI _shotsRelayedText;
+
+        [Header("Expanded Panel")]
+        [SerializeField] private GameObject _expandedPanel;
+        [SerializeField] private Button _disableButton;
+        [SerializeField] private TextMeshProUGUI _durationText;
+
+        [Header("Settings")]
+        [SerializeField] private CanvasGroup _canvasGroup;
+
+        #endregion
+
+        #region Private Fields
+
+        private RectTransform _rectTransform;
+        private Canvas _parentCanvas;
+        private bool _isVisible;
+        private bool _isExpanded;
+        private bool _isDragging;
+        private int _shotsRelayed;
+        private BridgeConnectionStatus _connectionStatus = BridgeConnectionStatus.Disconnected;
+        private DateTime _startTime;
+        private Coroutine _durationUpdateCoroutine;
+        private Vector2 _dragOffset;
+
+        // Animation
+        private Coroutine _fadeCoroutine;
+        private const float FadeDuration = 0.2f;
+
+        #endregion
+
+        #region Public Properties
+
+        /// <summary>Whether the overlay is visible.</summary>
+        public bool IsVisible => _isVisible;
+
+        /// <summary>Whether the expanded panel is showing.</summary>
+        public bool IsExpanded => _isExpanded;
+
+        /// <summary>Number of shots relayed this session.</summary>
+        public int ShotsRelayed => _shotsRelayed;
+
+        /// <summary>Current connection status.</summary>
+        public BridgeConnectionStatus ConnectionStatus => _connectionStatus;
+
+        #endregion
+
+        #region Events
+
+        /// <summary>Fired when the overlay is expanded.</summary>
+        public event Action OnExpanded;
+
+        /// <summary>Fired when the overlay is collapsed.</summary>
+        public event Action OnCollapsed;
+
+        /// <summary>Fired when connection status changes.</summary>
+        public event Action<BridgeConnectionStatus> OnConnectionStatusChanged;
+
+        /// <summary>Fired when shots relayed count changes.</summary>
+        public event Action<int> OnShotsRelayedChanged;
+
+        /// <summary>Fired when disable button is clicked.</summary>
+        public event Action OnDisableRequested;
+
+        #endregion
+
+        #region Unity Lifecycle
+
+        private void Awake()
+        {
+            _rectTransform = GetComponent<RectTransform>();
+            if (_rectTransform == null)
+            {
+                _rectTransform = gameObject.AddComponent<RectTransform>();
+            }
+
+            if (_canvasGroup == null)
+            {
+                _canvasGroup = GetComponent<CanvasGroup>();
+            }
+
+            _parentCanvas = GetComponentInParent<Canvas>();
+
+            // Initialize expanded panel as hidden
+            if (_expandedPanel != null)
+            {
+                _expandedPanel.SetActive(false);
+            }
+
+            // Wire up disable button
+            if (_disableButton != null)
+            {
+                _disableButton.onClick.AddListener(HandleDisableClick);
+            }
+        }
+
+        private void OnDestroy()
+        {
+            StopAllAnimations();
+
+            if (_disableButton != null)
+            {
+                _disableButton.onClick.RemoveListener(HandleDisableClick);
+            }
+        }
+
+        #endregion
+
+        #region IPointerClickHandler
+
+        public void OnPointerClick(PointerEventData eventData)
+        {
+            // Only toggle if not dragging
+            if (!_isDragging)
+            {
+                ToggleExpand();
+            }
+        }
+
+        #endregion
+
+        #region IDragHandler
+
+        public void OnBeginDrag(PointerEventData eventData)
+        {
+            _isDragging = true;
+
+            if (_rectTransform != null && _parentCanvas != null)
+            {
+                RectTransformUtility.ScreenPointToLocalPointInRectangle(
+                    _parentCanvas.transform as RectTransform,
+                    eventData.position,
+                    eventData.pressEventCamera,
+                    out Vector2 localPoint);
+
+                _dragOffset = (Vector2)_rectTransform.localPosition - localPoint;
+            }
+        }
+
+        public void OnDrag(PointerEventData eventData)
+        {
+            if (_rectTransform == null || _parentCanvas == null)
+            {
+                return;
+            }
+
+            RectTransformUtility.ScreenPointToLocalPointInRectangle(
+                _parentCanvas.transform as RectTransform,
+                eventData.position,
+                eventData.pressEventCamera,
+                out Vector2 localPoint);
+
+            _rectTransform.localPosition = localPoint + _dragOffset;
+        }
+
+        void IEndDragHandler.OnEndDrag(PointerEventData eventData)
+        {
+            // Reset dragging flag after a short delay to prevent click triggering
+            StartCoroutine(ResetDraggingFlag());
+        }
+
+        private IEnumerator ResetDraggingFlag()
+        {
+            yield return null; // Wait one frame
+            _isDragging = false;
+        }
+
+        #endregion
+
+        #region Public Methods
+
+        /// <summary>
+        /// Shows the overlay.
+        /// </summary>
+        /// <param name="animate">Whether to animate the transition.</param>
+        public void Show(bool animate = true)
+        {
+            _isVisible = true;
+            gameObject.SetActive(true);
+
+            if (animate && gameObject.activeInHierarchy)
+            {
+                StopFadeAnimation();
+                _fadeCoroutine = StartCoroutine(AnimateFade(1f));
+            }
+            else if (_canvasGroup != null)
+            {
+                _canvasGroup.alpha = 1f;
+            }
+
+            // Start duration updates
+            _startTime = DateTime.UtcNow;
+            StartDurationUpdates();
+        }
+
+        /// <summary>
+        /// Hides the overlay.
+        /// </summary>
+        /// <param name="animate">Whether to animate the transition.</param>
+        public void Hide(bool animate = true)
+        {
+            _isVisible = false;
+            StopDurationUpdates();
+
+            if (animate && gameObject.activeInHierarchy)
+            {
+                StopFadeAnimation();
+                _fadeCoroutine = StartCoroutine(AnimateFadeAndDeactivate());
+            }
+            else
+            {
+                if (_canvasGroup != null)
+                {
+                    _canvasGroup.alpha = 0f;
+                }
+                gameObject.SetActive(false);
+            }
+        }
+
+        /// <summary>
+        /// Expands the overlay to show additional controls.
+        /// </summary>
+        /// <param name="animate">Whether to animate the transition.</param>
+        public void Expand(bool animate = true)
+        {
+            if (_isExpanded) return;
+
+            _isExpanded = true;
+
+            if (_expandedPanel != null)
+            {
+                _expandedPanel.SetActive(true);
+            }
+
+            OnExpanded?.Invoke();
+        }
+
+        /// <summary>
+        /// Collapses the overlay to minimal view.
+        /// </summary>
+        /// <param name="animate">Whether to animate the transition.</param>
+        public void Collapse(bool animate = true)
+        {
+            if (!_isExpanded) return;
+
+            _isExpanded = false;
+
+            if (_expandedPanel != null)
+            {
+                _expandedPanel.SetActive(false);
+            }
+
+            OnCollapsed?.Invoke();
+        }
+
+        /// <summary>
+        /// Toggles between expanded and collapsed states.
+        /// </summary>
+        /// <param name="animate">Whether to animate the transition.</param>
+        public void ToggleExpand(bool animate = true)
+        {
+            if (_isExpanded)
+            {
+                Collapse(animate);
+            }
+            else
+            {
+                Expand(animate);
+            }
+        }
+
+        /// <summary>
+        /// Updates the connection status display.
+        /// </summary>
+        /// <param name="status">New connection status.</param>
+        public void UpdateConnectionStatus(BridgeConnectionStatus status)
+        {
+            if (_connectionStatus == status) return;
+
+            _connectionStatus = status;
+
+            // Update visuals
+            if (_statusIcon != null)
+            {
+                _statusIcon.color = GetStatusColor(status);
+            }
+
+            if (_statusText != null)
+            {
+                _statusText.text = GetStatusText(status);
+            }
+
+            OnConnectionStatusChanged?.Invoke(status);
+        }
+
+        /// <summary>
+        /// Updates the shots relayed count.
+        /// </summary>
+        /// <param name="count">New shot count.</param>
+        public void UpdateShotsRelayed(int count)
+        {
+            _shotsRelayed = count;
+
+            if (_shotsRelayedText != null)
+            {
+                _shotsRelayedText.text = FormatShotsText(count);
+            }
+
+            OnShotsRelayedChanged?.Invoke(count);
+        }
+
+        /// <summary>
+        /// Increments the shots relayed count by one.
+        /// </summary>
+        public void IncrementShotsRelayed()
+        {
+            UpdateShotsRelayed(_shotsRelayed + 1);
+        }
+
+        /// <summary>
+        /// Resets the shots relayed count to zero.
+        /// </summary>
+        public void ResetShotsRelayed()
+        {
+            UpdateShotsRelayed(0);
+        }
+
+        /// <summary>
+        /// Sets references for testing.
+        /// </summary>
+        internal void SetReferences(Image statusIcon, TextMeshProUGUI statusText,
+            TextMeshProUGUI shotsRelayedText, GameObject expandedPanel, CanvasGroup canvasGroup)
+        {
+            _statusIcon = statusIcon;
+            _statusText = statusText;
+            _shotsRelayedText = shotsRelayedText;
+            _expandedPanel = expandedPanel;
+            _canvasGroup = canvasGroup;
+
+            if (_expandedPanel != null)
+            {
+                _expandedPanel.SetActive(false);
+            }
+        }
+
+        #endregion
+
+        #region Static Helper Methods
+
+        /// <summary>
+        /// Gets the display text for a connection status.
+        /// </summary>
+        public static string GetStatusText(BridgeConnectionStatus status)
+        {
+            return status switch
+            {
+                BridgeConnectionStatus.Connected => "GSPro Connected",
+                BridgeConnectionStatus.Connecting => "Connecting...",
+                BridgeConnectionStatus.Disconnected => "Disconnected",
+                BridgeConnectionStatus.Error => "Connection Error",
+                _ => "Unknown"
+            };
+        }
+
+        /// <summary>
+        /// Gets the display color for a connection status.
+        /// </summary>
+        public static Color GetStatusColor(BridgeConnectionStatus status)
+        {
+            return status switch
+            {
+                BridgeConnectionStatus.Connected => ConnectedColor,
+                BridgeConnectionStatus.Connecting => ConnectingColor,
+                BridgeConnectionStatus.Disconnected => DisconnectedColor,
+                BridgeConnectionStatus.Error => ErrorColor,
+                _ => DisconnectedColor
+            };
+        }
+
+        /// <summary>
+        /// Formats the shots count with proper singular/plural form.
+        /// </summary>
+        public static string FormatShotsText(int count)
+        {
+            return count == 1 ? "1 shot" : $"{count} shots";
+        }
+
+        #endregion
+
+        #region Private Methods
+
+        private void HandleDisableClick()
+        {
+            OnDisableRequested?.Invoke();
+        }
+
+        private void StartDurationUpdates()
+        {
+            StopDurationUpdates();
+            if (gameObject.activeInHierarchy)
+            {
+                _durationUpdateCoroutine = StartCoroutine(UpdateDurationLoop());
+            }
+        }
+
+        private void StopDurationUpdates()
+        {
+            if (_durationUpdateCoroutine != null)
+            {
+                StopCoroutine(_durationUpdateCoroutine);
+                _durationUpdateCoroutine = null;
+            }
+        }
+
+        private IEnumerator UpdateDurationLoop()
+        {
+            while (_isVisible)
+            {
+                UpdateDurationDisplay();
+                yield return new WaitForSeconds(1f);
+            }
+        }
+
+        private void UpdateDurationDisplay()
+        {
+            if (_durationText == null) return;
+
+            TimeSpan duration = DateTime.UtcNow - _startTime;
+            _durationText.text = FormatDuration(duration);
+        }
+
+        private string FormatDuration(TimeSpan duration)
+        {
+            if (duration.TotalHours >= 1)
+            {
+                return $"{(int)duration.TotalHours}h {duration.Minutes:D2}m";
+            }
+            else
+            {
+                return $"{duration.Minutes}m {duration.Seconds:D2}s";
+            }
+        }
+
+        private void StopFadeAnimation()
+        {
+            if (_fadeCoroutine != null)
+            {
+                StopCoroutine(_fadeCoroutine);
+                _fadeCoroutine = null;
+            }
+        }
+
+        private void StopAllAnimations()
+        {
+            StopFadeAnimation();
+            StopDurationUpdates();
+        }
+
+        private IEnumerator AnimateFade(float targetAlpha)
+        {
+            if (_canvasGroup == null)
+            {
+                yield break;
+            }
+
+            float startAlpha = _canvasGroup.alpha;
+            float elapsed = 0f;
+
+            while (elapsed < FadeDuration)
+            {
+                elapsed += Time.deltaTime;
+                float t = elapsed / FadeDuration;
+                _canvasGroup.alpha = Mathf.Lerp(startAlpha, targetAlpha, t);
+                yield return null;
+            }
+
+            _canvasGroup.alpha = targetAlpha;
+            _fadeCoroutine = null;
+        }
+
+        private IEnumerator AnimateFadeAndDeactivate()
+        {
+            yield return AnimateFade(0f);
+            gameObject.SetActive(false);
+        }
+
+        #endregion
+    }
+}

--- a/Assets/Scripts/UI/BridgeModeOverlay.cs.meta
+++ b/Assets/Scripts/UI/BridgeModeOverlay.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: ffb67cae0839c4920aabf9db8d20c966

--- a/Assets/Scripts/UI/BridgeModeToggle.cs
+++ b/Assets/Scripts/UI/BridgeModeToggle.cs
@@ -1,0 +1,404 @@
+// ABOUTME: UI component for enabling/disabling Bridge Mode with GSPro configuration.
+// ABOUTME: Shows toggle, host/port inputs, battery warning, and connection status.
+
+using System;
+using TMPro;
+using UnityEngine;
+using UnityEngine.UI;
+
+namespace OpenRange.UI
+{
+    /// <summary>
+    /// UI component for enabling and configuring Bridge Mode.
+    /// Includes toggle, GSPro connection settings, and status display.
+    /// </summary>
+    public class BridgeModeToggle : MonoBehaviour
+    {
+        #region Static Constants
+
+        /// <summary>Default GSPro host.</summary>
+        public const string DefaultHost = "localhost";
+
+        /// <summary>Default GSPro port.</summary>
+        public const int DefaultPort = 921;
+
+        /// <summary>Green color for connected status.</summary>
+        public static readonly Color ConnectedColor = new Color(0.2f, 0.9f, 0.2f, 1f);
+
+        /// <summary>Gray color for disconnected status.</summary>
+        public static readonly Color DisconnectedColor = new Color(0.6f, 0.6f, 0.6f, 1f);
+
+        /// <summary>Yellow color for connecting status.</summary>
+        public static readonly Color ConnectingColor = new Color(1f, 0.8f, 0.2f, 1f);
+
+        /// <summary>Red color for error status.</summary>
+        public static readonly Color ErrorColor = new Color(0.9f, 0.3f, 0.3f, 1f);
+
+        #endregion
+
+        #region Serialized Fields
+
+        [Header("Main Toggle")]
+        [SerializeField] private Toggle _enableToggle;
+        [SerializeField] private TextMeshProUGUI _titleText;
+        [SerializeField] private TextMeshProUGUI _descriptionText;
+
+        [Header("Configuration Panel")]
+        [SerializeField] private CanvasGroup _configPanel;
+        [SerializeField] private TMP_InputField _hostInput;
+        [SerializeField] private TMP_InputField _portInput;
+        [SerializeField] private Button _connectButton;
+        [SerializeField] private TextMeshProUGUI _connectButtonText;
+        [SerializeField] private TextMeshProUGUI _statusText;
+
+        [Header("Warnings")]
+        [SerializeField] private TextMeshProUGUI _batteryWarningText;
+
+        #endregion
+
+        #region Private Fields
+
+        private bool _isEnabled;
+        private string _host = DefaultHost;
+        private int _port = DefaultPort;
+        private bool _isConnected;
+
+        #endregion
+
+        #region Public Properties
+
+        /// <summary>Whether Bridge Mode is enabled.</summary>
+        public bool IsEnabled => _isEnabled;
+
+        /// <summary>GSPro host address.</summary>
+        public string Host => _host;
+
+        /// <summary>GSPro port.</summary>
+        public int Port => _port;
+
+        /// <summary>Whether currently connected to GSPro.</summary>
+        public bool IsConnected => _isConnected;
+
+        #endregion
+
+        #region Events
+
+        /// <summary>Fired when Bridge Mode enabled state changes.</summary>
+        public event Action<bool> OnEnabledChanged;
+
+        /// <summary>Fired when host address changes.</summary>
+        public event Action<string> OnHostChanged;
+
+        /// <summary>Fired when port changes.</summary>
+        public event Action<int> OnPortChanged;
+
+        /// <summary>Fired when connect button is clicked.</summary>
+        public event Action OnConnectClicked;
+
+        #endregion
+
+        #region Unity Lifecycle
+
+        private void Awake()
+        {
+            InitializeUI();
+            WireUpEvents();
+        }
+
+        private void OnDestroy()
+        {
+            UnwireEvents();
+        }
+
+        #endregion
+
+        #region Public Methods
+
+        /// <summary>
+        /// Sets the enabled state of Bridge Mode.
+        /// </summary>
+        /// <param name="enabled">Whether to enable Bridge Mode.</param>
+        public void SetEnabled(bool enabled)
+        {
+            if (_isEnabled == enabled) return;
+
+            _isEnabled = enabled;
+
+            // Update toggle UI
+            if (_enableToggle != null)
+            {
+                _enableToggle.SetIsOnWithoutNotify(enabled);
+            }
+
+            // Show/hide config panel
+            UpdateConfigPanelVisibility();
+
+            OnEnabledChanged?.Invoke(enabled);
+        }
+
+        /// <summary>
+        /// Sets the GSPro host address.
+        /// </summary>
+        /// <param name="host">Host address.</param>
+        public void SetHost(string host)
+        {
+            _host = string.IsNullOrEmpty(host) ? DefaultHost : host;
+
+            if (_hostInput != null)
+            {
+                _hostInput.SetTextWithoutNotify(_host);
+            }
+        }
+
+        /// <summary>
+        /// Sets the GSPro port.
+        /// </summary>
+        /// <param name="port">Port number.</param>
+        public void SetPort(int port)
+        {
+            _port = port <= 0 ? DefaultPort : port;
+
+            if (_portInput != null)
+            {
+                _portInput.SetTextWithoutNotify(_port.ToString());
+            }
+        }
+
+        /// <summary>
+        /// Sets both host and port configuration.
+        /// </summary>
+        /// <param name="host">Host address.</param>
+        /// <param name="port">Port number.</param>
+        public void SetConfiguration(string host, int port)
+        {
+            SetHost(host);
+            SetPort(port);
+        }
+
+        /// <summary>
+        /// Updates the status text display.
+        /// </summary>
+        /// <param name="status">Status message to display.</param>
+        /// <param name="isConnected">Whether connected (affects color).</param>
+        /// <param name="isError">Whether this is an error state.</param>
+        public void UpdateStatus(string status, bool isConnected = false, bool isError = false)
+        {
+            _isConnected = isConnected;
+
+            if (_statusText != null)
+            {
+                _statusText.text = status;
+                _statusText.color = isError ? ErrorColor
+                    : isConnected ? ConnectedColor
+                    : DisconnectedColor;
+            }
+        }
+
+        /// <summary>
+        /// Shows or hides the battery warning.
+        /// </summary>
+        /// <param name="show">Whether to show the warning.</param>
+        public void ShowBatteryWarning(bool show)
+        {
+            if (_batteryWarningText != null)
+            {
+                _batteryWarningText.gameObject.SetActive(show);
+            }
+        }
+
+        /// <summary>
+        /// Enables or disables the connect button.
+        /// </summary>
+        /// <param name="enabled">Whether the button should be interactable.</param>
+        public void SetConnectButtonEnabled(bool enabled)
+        {
+            if (_connectButton != null)
+            {
+                _connectButton.interactable = enabled;
+            }
+        }
+
+        /// <summary>
+        /// Sets the connect button text.
+        /// </summary>
+        /// <param name="text">Button text.</param>
+        public void SetConnectButtonText(string text)
+        {
+            if (_connectButtonText != null)
+            {
+                _connectButtonText.text = text;
+            }
+            else if (_connectButton != null)
+            {
+                // Try to find text component in button
+                var buttonText = _connectButton.GetComponentInChildren<TextMeshProUGUI>();
+                if (buttonText != null)
+                {
+                    buttonText.text = text;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Sets references for testing.
+        /// </summary>
+        internal void SetReferences(Toggle enableToggle, TMP_InputField hostInput,
+            TMP_InputField portInput, TextMeshProUGUI statusText,
+            TextMeshProUGUI batteryWarningText, Button connectButton, CanvasGroup configPanel)
+        {
+            _enableToggle = enableToggle;
+            _hostInput = hostInput;
+            _portInput = portInput;
+            _statusText = statusText;
+            _batteryWarningText = batteryWarningText;
+            _connectButton = connectButton;
+            _configPanel = configPanel;
+
+            // Initialize
+            if (_enableToggle != null)
+            {
+                _enableToggle.SetIsOnWithoutNotify(false);
+            }
+
+            if (_hostInput != null)
+            {
+                _hostInput.SetTextWithoutNotify(_host);
+            }
+
+            if (_portInput != null)
+            {
+                _portInput.SetTextWithoutNotify(_port.ToString());
+            }
+
+            if (_configPanel != null)
+            {
+                _configPanel.alpha = 0f;
+            }
+
+            if (_batteryWarningText != null)
+            {
+                _batteryWarningText.gameObject.SetActive(false);
+            }
+
+            WireUpEvents();
+        }
+
+        #endregion
+
+        #region Private Methods
+
+        private void InitializeUI()
+        {
+            // Set default values in input fields
+            if (_hostInput != null)
+            {
+                _hostInput.text = _host;
+            }
+
+            if (_portInput != null)
+            {
+                _portInput.text = _port.ToString();
+            }
+
+            // Initialize config panel visibility
+            UpdateConfigPanelVisibility();
+
+            // Hide battery warning initially
+            if (_batteryWarningText != null)
+            {
+                _batteryWarningText.gameObject.SetActive(false);
+            }
+        }
+
+        private void WireUpEvents()
+        {
+            if (_enableToggle != null)
+            {
+                _enableToggle.onValueChanged.AddListener(HandleToggleChanged);
+            }
+
+            if (_hostInput != null)
+            {
+                _hostInput.onEndEdit.AddListener(HandleHostChanged);
+            }
+
+            if (_portInput != null)
+            {
+                _portInput.onEndEdit.AddListener(HandlePortChanged);
+            }
+
+            if (_connectButton != null)
+            {
+                _connectButton.onClick.AddListener(HandleConnectClicked);
+            }
+        }
+
+        private void UnwireEvents()
+        {
+            if (_enableToggle != null)
+            {
+                _enableToggle.onValueChanged.RemoveListener(HandleToggleChanged);
+            }
+
+            if (_hostInput != null)
+            {
+                _hostInput.onEndEdit.RemoveListener(HandleHostChanged);
+            }
+
+            if (_portInput != null)
+            {
+                _portInput.onEndEdit.RemoveListener(HandlePortChanged);
+            }
+
+            if (_connectButton != null)
+            {
+                _connectButton.onClick.RemoveListener(HandleConnectClicked);
+            }
+        }
+
+        private void UpdateConfigPanelVisibility()
+        {
+            if (_configPanel != null)
+            {
+                _configPanel.alpha = _isEnabled ? 1f : 0f;
+                _configPanel.interactable = _isEnabled;
+                _configPanel.blocksRaycasts = _isEnabled;
+            }
+        }
+
+        private void HandleToggleChanged(bool isOn)
+        {
+            SetEnabled(isOn);
+        }
+
+        private void HandleHostChanged(string value)
+        {
+            _host = string.IsNullOrEmpty(value) ? DefaultHost : value;
+            OnHostChanged?.Invoke(_host);
+        }
+
+        private void HandlePortChanged(string value)
+        {
+            if (int.TryParse(value, out int port) && port > 0)
+            {
+                _port = port;
+            }
+            else
+            {
+                _port = DefaultPort;
+                if (_portInput != null)
+                {
+                    _portInput.SetTextWithoutNotify(_port.ToString());
+                }
+            }
+            OnPortChanged?.Invoke(_port);
+        }
+
+        private void HandleConnectClicked()
+        {
+            OnConnectClicked?.Invoke();
+        }
+
+        #endregion
+    }
+}

--- a/Assets/Scripts/UI/BridgeModeToggle.cs.meta
+++ b/Assets/Scripts/UI/BridgeModeToggle.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 9527adc01227049c7a40db689b0a8061

--- a/Assets/Tests/EditMode/BridgeModeOverlayTests.cs
+++ b/Assets/Tests/EditMode/BridgeModeOverlayTests.cs
@@ -1,0 +1,421 @@
+// ABOUTME: Unit tests for BridgeModeOverlay UI component.
+// ABOUTME: Tests display states, statistics updates, expand/collapse, and drag functionality.
+
+using NUnit.Framework;
+using OpenRange.Core;
+using OpenRange.UI;
+using TMPro;
+using UnityEngine;
+using UnityEngine.UI;
+
+namespace OpenRange.Tests.EditMode
+{
+    [TestFixture]
+    public class BridgeModeOverlayTests
+    {
+        private GameObject _testGO;
+        private BridgeModeOverlay _overlay;
+        private Image _statusIcon;
+        private TextMeshProUGUI _statusText;
+        private TextMeshProUGUI _shotsRelayedText;
+        private GameObject _expandedPanel;
+        private CanvasGroup _canvasGroup;
+
+        [SetUp]
+        public void SetUp()
+        {
+            // Create test hierarchy
+            _testGO = new GameObject("BridgeModeOverlay");
+            _testGO.AddComponent<RectTransform>();
+            _canvasGroup = _testGO.AddComponent<CanvasGroup>();
+
+            // Create status icon
+            var iconGO = new GameObject("StatusIcon");
+            iconGO.transform.SetParent(_testGO.transform);
+            _statusIcon = iconGO.AddComponent<Image>();
+
+            // Create status text
+            var statusTextGO = new GameObject("StatusText");
+            statusTextGO.transform.SetParent(_testGO.transform);
+            _statusText = statusTextGO.AddComponent<TextMeshProUGUI>();
+
+            // Create shots relayed text
+            var shotsTextGO = new GameObject("ShotsRelayedText");
+            shotsTextGO.transform.SetParent(_testGO.transform);
+            _shotsRelayedText = shotsTextGO.AddComponent<TextMeshProUGUI>();
+
+            // Create expanded panel
+            _expandedPanel = new GameObject("ExpandedPanel");
+            _expandedPanel.transform.SetParent(_testGO.transform);
+            _expandedPanel.AddComponent<CanvasGroup>();
+
+            // Add component and set references
+            _overlay = _testGO.AddComponent<BridgeModeOverlay>();
+            _overlay.SetReferences(_statusIcon, _statusText, _shotsRelayedText, _expandedPanel, _canvasGroup);
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            if (_testGO != null)
+            {
+                Object.DestroyImmediate(_testGO);
+            }
+        }
+
+        #region Initial State Tests
+
+        [Test]
+        public void InitialState_IsCollapsed()
+        {
+            Assert.That(_overlay.IsExpanded, Is.False);
+        }
+
+        [Test]
+        public void InitialState_IsNotVisible()
+        {
+            Assert.That(_overlay.IsVisible, Is.False);
+        }
+
+        [Test]
+        public void InitialState_ShotsRelayed_IsZero()
+        {
+            Assert.That(_overlay.ShotsRelayed, Is.EqualTo(0));
+        }
+
+        [Test]
+        public void InitialState_ConnectionStatus_IsDisconnected()
+        {
+            Assert.That(_overlay.ConnectionStatus, Is.EqualTo(BridgeConnectionStatus.Disconnected));
+        }
+
+        #endregion
+
+        #region Visibility Tests
+
+        [Test]
+        public void Show_SetsIsVisibleTrue()
+        {
+            _overlay.Show(animate: false);
+
+            Assert.That(_overlay.IsVisible, Is.True);
+        }
+
+        [Test]
+        public void Show_SetsCanvasGroupAlphaToOne()
+        {
+            _overlay.Show(animate: false);
+
+            Assert.That(_canvasGroup.alpha, Is.EqualTo(1f));
+        }
+
+        [Test]
+        public void Hide_SetsIsVisibleFalse()
+        {
+            _overlay.Show(animate: false);
+            _overlay.Hide(animate: false);
+
+            Assert.That(_overlay.IsVisible, Is.False);
+        }
+
+        [Test]
+        public void Hide_SetsCanvasGroupAlphaToZero()
+        {
+            _overlay.Show(animate: false);
+            _overlay.Hide(animate: false);
+
+            Assert.That(_canvasGroup.alpha, Is.EqualTo(0f));
+        }
+
+        #endregion
+
+        #region Expand/Collapse Tests
+
+        [Test]
+        public void Expand_SetsIsExpandedTrue()
+        {
+            _overlay.Expand(animate: false);
+
+            Assert.That(_overlay.IsExpanded, Is.True);
+        }
+
+        [Test]
+        public void Expand_ShowsExpandedPanel()
+        {
+            _overlay.Expand(animate: false);
+
+            Assert.That(_expandedPanel.activeSelf, Is.True);
+        }
+
+        [Test]
+        public void Collapse_SetsIsExpandedFalse()
+        {
+            _overlay.Expand(animate: false);
+            _overlay.Collapse(animate: false);
+
+            Assert.That(_overlay.IsExpanded, Is.False);
+        }
+
+        [Test]
+        public void Collapse_HidesExpandedPanel()
+        {
+            _overlay.Expand(animate: false);
+            _overlay.Collapse(animate: false);
+
+            Assert.That(_expandedPanel.activeSelf, Is.False);
+        }
+
+        [Test]
+        public void ToggleExpand_TogglesState()
+        {
+            Assert.That(_overlay.IsExpanded, Is.False);
+
+            _overlay.ToggleExpand(animate: false);
+            Assert.That(_overlay.IsExpanded, Is.True);
+
+            _overlay.ToggleExpand(animate: false);
+            Assert.That(_overlay.IsExpanded, Is.False);
+        }
+
+        [Test]
+        public void Expand_FiresOnExpandedEvent()
+        {
+            bool eventFired = false;
+            _overlay.OnExpanded += () => eventFired = true;
+
+            _overlay.Expand(animate: false);
+
+            Assert.That(eventFired, Is.True);
+        }
+
+        [Test]
+        public void Collapse_FiresOnCollapsedEvent()
+        {
+            _overlay.Expand(animate: false);
+            bool eventFired = false;
+            _overlay.OnCollapsed += () => eventFired = true;
+
+            _overlay.Collapse(animate: false);
+
+            Assert.That(eventFired, Is.True);
+        }
+
+        #endregion
+
+        #region Connection Status Tests
+
+        [Test]
+        public void UpdateConnectionStatus_Connected_UpdatesStatus()
+        {
+            _overlay.UpdateConnectionStatus(BridgeConnectionStatus.Connected);
+
+            Assert.That(_overlay.ConnectionStatus, Is.EqualTo(BridgeConnectionStatus.Connected));
+        }
+
+        [Test]
+        public void UpdateConnectionStatus_Connected_SetsGreenColor()
+        {
+            _overlay.UpdateConnectionStatus(BridgeConnectionStatus.Connected);
+
+            Assert.That(_statusIcon.color, Is.EqualTo(BridgeModeOverlay.ConnectedColor));
+        }
+
+        [Test]
+        public void UpdateConnectionStatus_Connecting_SetsYellowColor()
+        {
+            _overlay.UpdateConnectionStatus(BridgeConnectionStatus.Connecting);
+
+            Assert.That(_statusIcon.color, Is.EqualTo(BridgeModeOverlay.ConnectingColor));
+        }
+
+        [Test]
+        public void UpdateConnectionStatus_Disconnected_SetsGrayColor()
+        {
+            // First set to a different status, then test Disconnected
+            _overlay.UpdateConnectionStatus(BridgeConnectionStatus.Connected);
+            _overlay.UpdateConnectionStatus(BridgeConnectionStatus.Disconnected);
+
+            Assert.That(_statusIcon.color, Is.EqualTo(BridgeModeOverlay.DisconnectedColor));
+        }
+
+        [Test]
+        public void UpdateConnectionStatus_Error_SetsRedColor()
+        {
+            _overlay.UpdateConnectionStatus(BridgeConnectionStatus.Error);
+
+            Assert.That(_statusIcon.color, Is.EqualTo(BridgeModeOverlay.ErrorColor));
+        }
+
+        [Test]
+        public void UpdateConnectionStatus_Connected_UpdatesStatusText()
+        {
+            _overlay.UpdateConnectionStatus(BridgeConnectionStatus.Connected);
+
+            Assert.That(_statusText.text, Is.EqualTo("GSPro Connected"));
+        }
+
+        [Test]
+        public void UpdateConnectionStatus_Connecting_UpdatesStatusText()
+        {
+            _overlay.UpdateConnectionStatus(BridgeConnectionStatus.Connecting);
+
+            Assert.That(_statusText.text, Is.EqualTo("Connecting..."));
+        }
+
+        [Test]
+        public void UpdateConnectionStatus_Disconnected_UpdatesStatusText()
+        {
+            // First set to a different status, then test Disconnected
+            _overlay.UpdateConnectionStatus(BridgeConnectionStatus.Connected);
+            _overlay.UpdateConnectionStatus(BridgeConnectionStatus.Disconnected);
+
+            Assert.That(_statusText.text, Is.EqualTo("Disconnected"));
+        }
+
+        [Test]
+        public void UpdateConnectionStatus_FiresOnConnectionStatusChangedEvent()
+        {
+            BridgeConnectionStatus receivedStatus = BridgeConnectionStatus.Disconnected;
+            _overlay.OnConnectionStatusChanged += status => receivedStatus = status;
+
+            _overlay.UpdateConnectionStatus(BridgeConnectionStatus.Connected);
+
+            Assert.That(receivedStatus, Is.EqualTo(BridgeConnectionStatus.Connected));
+        }
+
+        #endregion
+
+        #region Shots Relayed Tests
+
+        [Test]
+        public void UpdateShotsRelayed_UpdatesCount()
+        {
+            _overlay.UpdateShotsRelayed(5);
+
+            Assert.That(_overlay.ShotsRelayed, Is.EqualTo(5));
+        }
+
+        [Test]
+        public void UpdateShotsRelayed_UpdatesText()
+        {
+            _overlay.UpdateShotsRelayed(42);
+
+            Assert.That(_shotsRelayedText.text, Is.EqualTo("42 shots"));
+        }
+
+        [Test]
+        public void UpdateShotsRelayed_One_ShowsSingular()
+        {
+            _overlay.UpdateShotsRelayed(1);
+
+            Assert.That(_shotsRelayedText.text, Is.EqualTo("1 shot"));
+        }
+
+        [Test]
+        public void UpdateShotsRelayed_Zero_ShowsPlural()
+        {
+            _overlay.UpdateShotsRelayed(0);
+
+            Assert.That(_shotsRelayedText.text, Is.EqualTo("0 shots"));
+        }
+
+        [Test]
+        public void UpdateShotsRelayed_FiresOnShotsRelayedChangedEvent()
+        {
+            int receivedCount = 0;
+            _overlay.OnShotsRelayedChanged += count => receivedCount = count;
+
+            _overlay.UpdateShotsRelayed(7);
+
+            Assert.That(receivedCount, Is.EqualTo(7));
+        }
+
+        [Test]
+        public void IncrementShotsRelayed_IncrementsCount()
+        {
+            _overlay.UpdateShotsRelayed(5);
+            _overlay.IncrementShotsRelayed();
+
+            Assert.That(_overlay.ShotsRelayed, Is.EqualTo(6));
+        }
+
+        [Test]
+        public void ResetShotsRelayed_SetsCountToZero()
+        {
+            _overlay.UpdateShotsRelayed(10);
+            _overlay.ResetShotsRelayed();
+
+            Assert.That(_overlay.ShotsRelayed, Is.EqualTo(0));
+        }
+
+        #endregion
+
+        #region Static Helper Tests
+
+        [Test]
+        public void GetStatusText_Connected_ReturnsCorrectText()
+        {
+            Assert.That(BridgeModeOverlay.GetStatusText(BridgeConnectionStatus.Connected),
+                Is.EqualTo("GSPro Connected"));
+        }
+
+        [Test]
+        public void GetStatusText_Connecting_ReturnsCorrectText()
+        {
+            Assert.That(BridgeModeOverlay.GetStatusText(BridgeConnectionStatus.Connecting),
+                Is.EqualTo("Connecting..."));
+        }
+
+        [Test]
+        public void GetStatusText_Disconnected_ReturnsCorrectText()
+        {
+            Assert.That(BridgeModeOverlay.GetStatusText(BridgeConnectionStatus.Disconnected),
+                Is.EqualTo("Disconnected"));
+        }
+
+        [Test]
+        public void GetStatusText_Error_ReturnsCorrectText()
+        {
+            Assert.That(BridgeModeOverlay.GetStatusText(BridgeConnectionStatus.Error),
+                Is.EqualTo("Connection Error"));
+        }
+
+        [Test]
+        public void GetStatusColor_Connected_ReturnsGreen()
+        {
+            Assert.That(BridgeModeOverlay.GetStatusColor(BridgeConnectionStatus.Connected),
+                Is.EqualTo(BridgeModeOverlay.ConnectedColor));
+        }
+
+        [Test]
+        public void GetStatusColor_Error_ReturnsRed()
+        {
+            Assert.That(BridgeModeOverlay.GetStatusColor(BridgeConnectionStatus.Error),
+                Is.EqualTo(BridgeModeOverlay.ErrorColor));
+        }
+
+        #endregion
+
+        #region Format Shots Text Tests
+
+        [Test]
+        public void FormatShotsText_Zero_ReturnsPlural()
+        {
+            Assert.That(BridgeModeOverlay.FormatShotsText(0), Is.EqualTo("0 shots"));
+        }
+
+        [Test]
+        public void FormatShotsText_One_ReturnsSingular()
+        {
+            Assert.That(BridgeModeOverlay.FormatShotsText(1), Is.EqualTo("1 shot"));
+        }
+
+        [Test]
+        public void FormatShotsText_Many_ReturnsPlural()
+        {
+            Assert.That(BridgeModeOverlay.FormatShotsText(100), Is.EqualTo("100 shots"));
+        }
+
+        #endregion
+    }
+}

--- a/Assets/Tests/EditMode/BridgeModeOverlayTests.cs.meta
+++ b/Assets/Tests/EditMode/BridgeModeOverlayTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: b47daba8c64f14af69f06b8e0228e6fd

--- a/Assets/Tests/EditMode/BridgeModeToggleTests.cs
+++ b/Assets/Tests/EditMode/BridgeModeToggleTests.cs
@@ -1,0 +1,392 @@
+// ABOUTME: Unit tests for BridgeModeToggle UI component.
+// ABOUTME: Tests toggle state, GSPro config display, enable/disable functionality.
+
+using NUnit.Framework;
+using OpenRange.Core;
+using OpenRange.UI;
+using TMPro;
+using UnityEngine;
+using UnityEngine.UI;
+
+namespace OpenRange.Tests.EditMode
+{
+    [TestFixture]
+    public class BridgeModeToggleTests
+    {
+        private GameObject _testGO;
+        private BridgeModeToggle _toggle;
+        private Toggle _enableToggle;
+        private TMP_InputField _hostInput;
+        private TMP_InputField _portInput;
+        private TextMeshProUGUI _statusText;
+        private TextMeshProUGUI _batteryWarningText;
+        private Button _connectButton;
+        private CanvasGroup _configPanel;
+
+        [SetUp]
+        public void SetUp()
+        {
+            // Create test hierarchy
+            _testGO = new GameObject("BridgeModeToggle");
+
+            // Create enable toggle
+            var toggleGO = new GameObject("EnableToggle");
+            toggleGO.transform.SetParent(_testGO.transform);
+            _enableToggle = toggleGO.AddComponent<Toggle>();
+
+            // Create host input
+            var hostInputGO = new GameObject("HostInput");
+            hostInputGO.transform.SetParent(_testGO.transform);
+            _hostInput = hostInputGO.AddComponent<TMP_InputField>();
+            var hostTextGO = new GameObject("Text");
+            hostTextGO.transform.SetParent(hostInputGO.transform);
+            _hostInput.textComponent = hostTextGO.AddComponent<TextMeshProUGUI>();
+
+            // Create port input
+            var portInputGO = new GameObject("PortInput");
+            portInputGO.transform.SetParent(_testGO.transform);
+            _portInput = portInputGO.AddComponent<TMP_InputField>();
+            var portTextGO = new GameObject("Text");
+            portTextGO.transform.SetParent(portInputGO.transform);
+            _portInput.textComponent = portTextGO.AddComponent<TextMeshProUGUI>();
+
+            // Create status text
+            var statusTextGO = new GameObject("StatusText");
+            statusTextGO.transform.SetParent(_testGO.transform);
+            _statusText = statusTextGO.AddComponent<TextMeshProUGUI>();
+
+            // Create battery warning text
+            var batteryWarningGO = new GameObject("BatteryWarning");
+            batteryWarningGO.transform.SetParent(_testGO.transform);
+            _batteryWarningText = batteryWarningGO.AddComponent<TextMeshProUGUI>();
+
+            // Create connect button
+            var connectButtonGO = new GameObject("ConnectButton");
+            connectButtonGO.transform.SetParent(_testGO.transform);
+            _connectButton = connectButtonGO.AddComponent<Button>();
+
+            // Create config panel
+            var configPanelGO = new GameObject("ConfigPanel");
+            configPanelGO.transform.SetParent(_testGO.transform);
+            _configPanel = configPanelGO.AddComponent<CanvasGroup>();
+
+            // Add component and set references
+            _toggle = _testGO.AddComponent<BridgeModeToggle>();
+            _toggle.SetReferences(_enableToggle, _hostInput, _portInput, _statusText,
+                _batteryWarningText, _connectButton, _configPanel);
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            if (_testGO != null)
+            {
+                Object.DestroyImmediate(_testGO);
+            }
+        }
+
+        #region Initial State Tests
+
+        [Test]
+        public void InitialState_IsNotEnabled()
+        {
+            Assert.That(_toggle.IsEnabled, Is.False);
+        }
+
+        [Test]
+        public void InitialState_ToggleIsOff()
+        {
+            Assert.That(_enableToggle.isOn, Is.False);
+        }
+
+        [Test]
+        public void InitialState_DefaultHost_IsLocalhost()
+        {
+            Assert.That(_toggle.Host, Is.EqualTo("localhost"));
+        }
+
+        [Test]
+        public void InitialState_DefaultPort_Is921()
+        {
+            Assert.That(_toggle.Port, Is.EqualTo(921));
+        }
+
+        [Test]
+        public void InitialState_ConfigPanel_IsHidden()
+        {
+            Assert.That(_configPanel.alpha, Is.EqualTo(0f));
+        }
+
+        #endregion
+
+        #region Toggle State Tests
+
+        [Test]
+        public void SetEnabled_True_SetsIsEnabledTrue()
+        {
+            _toggle.SetEnabled(true);
+
+            Assert.That(_toggle.IsEnabled, Is.True);
+        }
+
+        [Test]
+        public void SetEnabled_True_TurnsToggleOn()
+        {
+            _toggle.SetEnabled(true);
+
+            Assert.That(_enableToggle.isOn, Is.True);
+        }
+
+        [Test]
+        public void SetEnabled_True_ShowsConfigPanel()
+        {
+            _toggle.SetEnabled(true);
+
+            Assert.That(_configPanel.alpha, Is.EqualTo(1f));
+        }
+
+        [Test]
+        public void SetEnabled_False_SetsIsEnabledFalse()
+        {
+            _toggle.SetEnabled(true);
+            _toggle.SetEnabled(false);
+
+            Assert.That(_toggle.IsEnabled, Is.False);
+        }
+
+        [Test]
+        public void SetEnabled_False_HidesConfigPanel()
+        {
+            _toggle.SetEnabled(true);
+            _toggle.SetEnabled(false);
+
+            Assert.That(_configPanel.alpha, Is.EqualTo(0f));
+        }
+
+        [Test]
+        public void SetEnabled_FiresOnEnabledChangedEvent()
+        {
+            bool? receivedValue = null;
+            _toggle.OnEnabledChanged += value => receivedValue = value;
+
+            _toggle.SetEnabled(true);
+
+            Assert.That(receivedValue, Is.True);
+        }
+
+        [Test]
+        public void SetEnabled_SameValue_DoesNotFireEvent()
+        {
+            int eventCount = 0;
+            _toggle.OnEnabledChanged += _ => eventCount++;
+
+            _toggle.SetEnabled(false);
+            _toggle.SetEnabled(false);
+
+            Assert.That(eventCount, Is.EqualTo(0));
+        }
+
+        #endregion
+
+        #region Host/Port Configuration Tests
+
+        [Test]
+        public void SetHost_UpdatesHostProperty()
+        {
+            _toggle.SetHost("192.168.1.100");
+
+            Assert.That(_toggle.Host, Is.EqualTo("192.168.1.100"));
+        }
+
+        [Test]
+        public void SetHost_UpdatesInputField()
+        {
+            _toggle.SetHost("192.168.1.100");
+
+            Assert.That(_hostInput.text, Is.EqualTo("192.168.1.100"));
+        }
+
+        [Test]
+        public void SetPort_UpdatesPortProperty()
+        {
+            _toggle.SetPort(9001);
+
+            Assert.That(_toggle.Port, Is.EqualTo(9001));
+        }
+
+        [Test]
+        public void SetPort_UpdatesInputField()
+        {
+            _toggle.SetPort(9001);
+
+            Assert.That(_portInput.text, Is.EqualTo("9001"));
+        }
+
+        [Test]
+        public void SetHost_Empty_DefaultsToLocalhost()
+        {
+            _toggle.SetHost("");
+
+            Assert.That(_toggle.Host, Is.EqualTo("localhost"));
+        }
+
+        [Test]
+        public void SetPort_Zero_DefaultsTo921()
+        {
+            _toggle.SetPort(0);
+
+            Assert.That(_toggle.Port, Is.EqualTo(921));
+        }
+
+        [Test]
+        public void SetPort_Negative_DefaultsTo921()
+        {
+            _toggle.SetPort(-1);
+
+            Assert.That(_toggle.Port, Is.EqualTo(921));
+        }
+
+        [Test]
+        public void SetConfiguration_SetsHostAndPort()
+        {
+            _toggle.SetConfiguration("10.0.0.1", 8080);
+
+            Assert.That(_toggle.Host, Is.EqualTo("10.0.0.1"));
+            Assert.That(_toggle.Port, Is.EqualTo(8080));
+        }
+
+        #endregion
+
+        #region Status Display Tests
+
+        [Test]
+        public void UpdateStatus_SetsStatusText()
+        {
+            _toggle.UpdateStatus("Connected to GSPro");
+
+            Assert.That(_statusText.text, Is.EqualTo("Connected to GSPro"));
+        }
+
+        [Test]
+        public void UpdateStatus_Connected_SetsGreenColor()
+        {
+            _toggle.UpdateStatus("Connected", isConnected: true);
+
+            Assert.That(_statusText.color, Is.EqualTo(BridgeModeToggle.ConnectedColor));
+        }
+
+        [Test]
+        public void UpdateStatus_Disconnected_SetsGrayColor()
+        {
+            _toggle.UpdateStatus("Disconnected", isConnected: false);
+
+            Assert.That(_statusText.color, Is.EqualTo(BridgeModeToggle.DisconnectedColor));
+        }
+
+        [Test]
+        public void ShowBatteryWarning_ShowsWarningText()
+        {
+            _toggle.ShowBatteryWarning(true);
+
+            Assert.That(_batteryWarningText.gameObject.activeSelf, Is.True);
+        }
+
+        [Test]
+        public void ShowBatteryWarning_False_HidesWarningText()
+        {
+            _toggle.ShowBatteryWarning(true);
+            _toggle.ShowBatteryWarning(false);
+
+            Assert.That(_batteryWarningText.gameObject.activeSelf, Is.False);
+        }
+
+        #endregion
+
+        #region Connect Button Tests
+
+        [Test]
+        public void SetConnectButtonEnabled_True_EnablesButton()
+        {
+            _toggle.SetConnectButtonEnabled(true);
+
+            Assert.That(_connectButton.interactable, Is.True);
+        }
+
+        [Test]
+        public void SetConnectButtonEnabled_False_DisablesButton()
+        {
+            _toggle.SetConnectButtonEnabled(false);
+
+            Assert.That(_connectButton.interactable, Is.False);
+        }
+
+        [Test]
+        public void SetConnectButtonText_UpdatesButtonText()
+        {
+            // Add button text component
+            var buttonTextGO = new GameObject("Text");
+            buttonTextGO.transform.SetParent(_connectButton.transform);
+            var buttonText = buttonTextGO.AddComponent<TextMeshProUGUI>();
+            _toggle.SetConnectButtonText("Disconnect");
+
+            // The button text should be updated if it exists
+            Assert.That(buttonText.text, Is.EqualTo("Disconnect"));
+        }
+
+        #endregion
+
+        #region Event Tests
+
+        [Test]
+        public void OnConnectClicked_FiresWhenButtonClicked()
+        {
+            bool eventFired = false;
+            _toggle.OnConnectClicked += () => eventFired = true;
+
+            // Simulate button click
+            _connectButton.onClick.Invoke();
+
+            Assert.That(eventFired, Is.True);
+        }
+
+        [Test]
+        public void OnHostChanged_FiresWhenHostInputChanges()
+        {
+            string receivedHost = null;
+            _toggle.OnHostChanged += host => receivedHost = host;
+
+            _hostInput.onEndEdit.Invoke("newhost.local");
+
+            Assert.That(receivedHost, Is.EqualTo("newhost.local"));
+        }
+
+        [Test]
+        public void OnPortChanged_FiresWhenPortInputChanges()
+        {
+            int receivedPort = 0;
+            _toggle.OnPortChanged += port => receivedPort = port;
+
+            _portInput.onEndEdit.Invoke("8888");
+
+            Assert.That(receivedPort, Is.EqualTo(8888));
+        }
+
+        #endregion
+
+        #region Static Constants Tests
+
+        [Test]
+        public void DefaultPort_Is921()
+        {
+            Assert.That(BridgeModeToggle.DefaultPort, Is.EqualTo(921));
+        }
+
+        [Test]
+        public void DefaultHost_IsLocalhost()
+        {
+            Assert.That(BridgeModeToggle.DefaultHost, Is.EqualTo("localhost"));
+        }
+
+        #endregion
+    }
+}

--- a/Assets/Tests/EditMode/BridgeModeToggleTests.cs.meta
+++ b/Assets/Tests/EditMode/BridgeModeToggleTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 61b78164c9f9541cb8d8332d4e91d113

--- a/todo.md
+++ b/todo.md
@@ -3,8 +3,10 @@
 ## Current Status
 **Phase**: 15 - Bridge Mode (In Progress)
 **Last Updated**: 2026-01-04
-**Next Prompt**: 57 (iOS PiP Workaround)
-**Test Count**: 1775 EditMode tests passing
+**Next Prompt**: 59 (Bridge Mode Testing - manual testing phase)
+**Test Count**: 1901 EditMode tests passing
+
+> **Note**: All iOS/iPad work (Prompts 26-28, 38, 57) deferred until other phases complete.
 
 ## Progress Summary
 ✅ Physics: Carry, bounce, roll validated (PRs #3, #33, #35, #37)
@@ -271,15 +273,18 @@ Use case: Moonlight streaming - run OpenRange on Android in background, stream G
   - [x] AndroidBridgeService.cs C# wrapper implementing IBridgeService
   - [x] Unit tests (32 tests, 5 stub tests on macOS)
 
-- [ ] **Prompt 57**: iOS PiP Workaround
+- [ ] **Prompt 57**: iOS PiP Workaround - DEFERRED
   - [ ] Research Picture-in-Picture as background workaround
   - [ ] Minimal video view to keep app active
   - [ ] Alternative: document iOS limitations
+  - > Deferred: All iOS/iPad work postponed until other phases complete
 
-- [ ] **Prompt 58**: Bridge Mode UI
-  - [ ] Minimal status overlay (connection, shots relayed)
-  - [ ] Quick toggle between full app and bridge mode
-  - [ ] Notification-based control
+- [x] **Prompt 58**: Bridge Mode UI ✅
+  - [x] Minimal status overlay (connection, shots relayed)
+  - [x] Quick toggle between full app and bridge mode
+  - [x] BridgeModeOverlay.cs with drag, expand/collapse, status colors
+  - [x] BridgeModeToggle.cs with GSPro config, battery warning
+  - [x] BridgeModeUIGenerator.cs editor tool
 
 - [ ] **Prompt 59**: Bridge Mode Testing
   - [ ] Test with Moonlight streaming
@@ -290,6 +295,8 @@ Use case: Moonlight streaming - run OpenRange on Android in background, stream G
 ---
 
 ## Recent Issue Log
+
+**2026-01-04**: Prompt 58 complete (PR #77). Bridge Mode UI: BridgeModeOverlay.cs (floating status with drag, expand/collapse, status colors), BridgeModeToggle.cs (enable toggle with GSPro config, battery warning), BridgeModeUIGenerator.cs (prefab creation). 73 new tests, 1901 total.
 
 **2026-01-04**: Prompt 56 complete (PR #75). Android foreground service for Bridge Mode: GC2BridgeService.kt with persistent notification, wake lock, START_STICKY. AndroidBridgeService.cs C# wrapper. 5 new tests (stub), 1775 total.
 


### PR DESCRIPTION
## Summary

Implements Prompt 58 from plan.md - Bridge Mode UI components for the Moonlight streaming use case.

### Components

- **BridgeModeOverlay.cs**: Floating status overlay for bridge mode
  - Connection status with color-coded states (connected, connecting, disconnected, error)
  - Shots relayed counter with singular/plural formatting
  - Expand/collapse for additional controls
  - Drag to reposition via IDragHandler interfaces
  - Tap to toggle expanded state
  - Fade animation for show/hide
  - Session duration display with auto-update

- **BridgeModeToggle.cs**: Settings toggle for enabling bridge mode
  - Enable/disable toggle with config panel visibility
  - GSPro host and port configuration inputs
  - Connect button with status text
  - Battery warning display option
  - Events: OnEnabledChanged, OnHostChanged, OnPortChanged, OnConnectClicked

- **BridgeModeUIGenerator.cs**: Editor tool for prefab creation
  - Menu: OpenRange > Create Bridge Mode Overlay Prefab
  - Menu: OpenRange > Create Bridge Mode Toggle Prefab
  - Menu: OpenRange > Create All Bridge Mode UI Prefabs

### Also

- Adds `.utmp/` to .gitignore (Unity Android build temp files)

## Tests

73 new unit tests (40 overlay + 33 toggle) covering:
- Initial state validation
- Visibility and animation states
- Expand/collapse behavior
- Connection status updates and colors
- Shots relayed formatting
- Host/port configuration
- Event firing
- Static helper methods

**Total: 1901 EditMode tests passing**

## Test Plan

- [x] BridgeModeOverlay visibility show/hide works
- [x] BridgeModeOverlay expand/collapse toggles panel
- [x] BridgeModeOverlay connection status colors update correctly
- [x] BridgeModeOverlay shots relayed counter increments
- [x] BridgeModeToggle enable/disable toggles config panel
- [x] BridgeModeToggle host/port configuration saves
- [x] BridgeModeToggle events fire correctly
- [x] All 1901 EditMode tests pass

Closes #76